### PR TITLE
fix Mod path discovery on apt and 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ in one variable:
 # workbenches relative to the binary.
 export FREECAD_LIB=/Applications/FreeCAD.app/Contents/Resources/lib
 
-# Linux (apt / PPA install) — three paths: the binding, the bundled
-# workbenches under lib/Mod, and the shared workbench tree.
-export FREECAD_LIB=/usr/lib/freecad/lib:/usr/lib/freecad/lib/Mod:/usr/share/freecad/Mod
+# Linux (apt / PPA install) — three paths: the binding under lib/,
+# the package-root Mod (often a symlink to /usr/share/freecad/Mod),
+# and the canonical workbench tree itself.
+export FREECAD_LIB=/usr/lib/freecad/lib:/usr/lib/freecad/Mod:/usr/share/freecad/Mod
 ```
 
 Verify the wiring:
@@ -157,3 +158,6 @@ Define `derived_candidates(bank, spec)` that returns
 ## License
 
 Apache 2.0 — see [`LICENSE`](LICENSE).
+
+This project depends on [FreeCAD](https://www.freecad.org/), which is
+licensed under LGPL 2.1+. FreeCAD is not bundled with this package.

--- a/src/freecad_validator/_freecad_loader.py
+++ b/src/freecad_validator/_freecad_loader.py
@@ -60,18 +60,16 @@ def _linux_mod_dirs(lib_dir: Path) -> Iterable[Path]:
     """Yield workbench/Mod directories that pair with a Linux ``lib``
     candidate. FreeCAD on apt/PPA installs splits the binding (under
     ``/usr/lib/freecad*/lib``) from its Python workbenches (under
-    ``/usr/lib/freecad*/lib/Mod`` and ``/usr/share/freecad*/Mod``);
-    the workbenches need to be on ``sys.path`` for ``FreeCAD.open()``
-    to deserialize ``Part``/``Sketcher``/``PartDesign`` objects.
-
-    Both ``freecad`` and ``freecad-python3`` packages typically share
-    ``/usr/share/freecad/Mod``, so we yield every plausible Mod root
-    and let the caller filter by :meth:`Path.is_dir`."""
-    # Sibling Mod next to the binding (e.g. /usr/lib/freecad/lib/Mod).
-    yield lib_dir / "Mod"
-    # Distro-shared workbench trees.
+    ``/usr/lib/freecad*/Mod`` and ``/usr/share/freecad*/Mod``); the
+    workbenches need to be on ``sys.path`` for ``FreeCAD.open()`` to
+    deserialize ``Part``/``Sketcher``/``PartDesign`` objects. The
+    caller filters by :meth:`Path.is_dir`."""
+    # Mod sits next to ``lib`` under the package root, e.g.
+    # /usr/lib/freecad/Mod (often a symlink into /usr/share/freecad/Mod).
+    yield lib_dir.parent / "Mod"
+    # Canonical workbench tree on apt/PPA, in case the symlink above
+    # is absent (custom builds, relocated installs).
     yield Path("/usr/share/freecad/Mod")
-    yield Path("/usr/share/freecad-python3/Mod")
 
 
 def _looks_like_freecad_lib(d: Path) -> bool:


### PR DESCRIPTION
_linux_mod_dirs yielded lib_dir / "Mod" — wrong on apt, where Mod sits as a sibling of lib under the package root (e.g. /usr/lib/freecad/Mod, often a symlink into /usr/share/freecad/Mod), not nested inside lib/. Use lib_dir.parent / "Mod" so auto-detect picks up Draft, PartDesign, and other pure-Python workbenches.

Also drop the dead /usr/share/freecad-python3/Mod yield (no apt package installs that path), correct the matching README comment in the FREECAD_LIB Linux example, and add a one-line acknowledgement that FreeCAD is LGPL 2.1+ and not bundled.