### PR TITLE
fix(render): route FreeCAD import through _freecad_loader

### DIFF
--- a/src/freecad_validator/render/render_freecad.py
+++ b/src/freecad_validator/render/render_freecad.py
@@ -8,11 +8,13 @@ import numpy as np
 import pyvista as pv
 
 # `FreeCAD` must precede `Mesh` — Mesh's C extension binds against FreeCAD
-# symbols and segfaults on macOS otherwise.
-# isort: off
-import FreeCAD
-import Mesh
-# isort: on
+# symbols and segfaults on macOS otherwise. Route through the project
+# loader so FreeCAD is discovered at common install paths without the
+# caller having to set PYTHONPATH / FREECAD_LIB.
+from freecad_validator._freecad_loader import import_freecad
+
+FreeCAD = import_freecad()
+import Mesh  # noqa: E402  — must come after FreeCAD import
 
 
 # ----------------------------- FreeCAD → Mesh -----------------------------


### PR DESCRIPTION
## Summary

`src/freecad_validator/render/render_freecad.py` did a top-level `import FreeCAD`, bypassing the project's `_freecad_loader.import_freecad()` auto-discovery helper that every other consumer uses (`measurement/builder.py`, `comparators/geometry.py`).

Result: a user who ran `pip install 'gnucleus-freecad-validator[render]'` and then `freecad-validator render IN.FCStd OUT.png` would hit:

```
ModuleNotFoundError: No module named 'FreeCAD'
```

…even with FreeCAD installed at a standard location (e.g. `/Applications/FreeCAD.app/...` on macOS), unless they had separately exported `PYTHONPATH` or `FREECAD_LIB`.

This patch routes the import through `import_freecad()` so `render` matches the rest of the codebase.

## Test plan

- [x] Smoke render on a sanity-dataset FCStd (gear case `4a6abbd059`) without `PYTHONPATH` set — produces the expected PNG.
- [x] Byte-identical PNG output before and after the patch (only the import resolution path changed).
- [x] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)