### PR TITLE
test(render): skip render-import test via freecad_available fixture

### DIFF
--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -58,14 +58,22 @@ def test_categories_are_registered_class_per_file():
         assert cat_subclasses, f"{mod.__name__} has no Category subclass"
 
 
-def test_render_module_imports():
+def test_render_module_imports(freecad_available):
     """`freecad_validator.render.render_freecad` imports cleanly when the
     `[render]` extra is installed. The module pulls in PyVista, NumPy,
     FreeCAD, and Mesh at module load, so this test is skipped in envs
     that lack any of those.
+
+    Uses the ``freecad_available`` fixture (conftest.py) instead of
+    ``pytest.importorskip("FreeCAD")`` because conftest installs a
+    no-op ``FreeCAD`` stub for the other import-smoke tests, which
+    would let ``importorskip`` succeed without real FreeCAD on PATH —
+    and then ``import Mesh`` (a sibling C extension, not a submodule)
+    fails because the lib dir was never added to sys.path.
     """
+    if not freecad_available:
+        pytest.skip("real FreeCAD module is not importable on this host")
     pytest.importorskip("pyvista")
-    pytest.importorskip("FreeCAD")  # Mesh imports follow once FreeCAD is up
     import freecad_validator.render.render_freecad as r  # noqa: F401
 
     # Public surface the CLI relies on.


### PR DESCRIPTION
## Summary

`test_render_module_imports` was failing on every host that didn't have `PYTHONPATH=/path/to/freecad/lib` set in the shell **before pytest started**, including:

- CI runners that don't install FreeCAD at all.
- Local dev machines with FreeCAD installed at a standard location (e.g. macOS Homebrew cask) but no `PYTHONPATH`.

## Root cause

\`conftest.py:34-35\` installs a no-op \`FreeCAD\` stub into \`sys.modules\` so the other import-smoke tests can run without a real FreeCAD module:

```python
if not _real_freecad_importable():
    sys.modules.setdefault("FreeCAD", types.ModuleType("FreeCAD"))
```

The render-import test gated itself with \`pytest.importorskip("FreeCAD")\`, which only checks "does \`import FreeCAD\` succeed." The stub satisfies that — so the test body kept running, hit \`import Mesh\` inside \`render_freecad.py\`, and failed because:

1. \`Mesh\` is a separate C extension (\`/Applications/FreeCAD.app/Contents/Resources/lib/Mesh.so\`), not a submodule of \`FreeCAD\`.
2. With the stub already in \`sys.modules\`, \`_freecad_loader.import_freecad()\`'s fast path returns immediately without adding the FreeCAD lib dir to \`sys.path\` — so \`Mesh.so\` can't be found.

## Fix

Use the existing \`freecad_available\` fixture from \`conftest.py:38-40\`, which checks \`FreeCAD.__file__\` (the stub lacks it):

```python
def test_render_module_imports(freecad_available):
    if not freecad_available:
        pytest.skip("real FreeCAD module is not importable on this host")
    pytest.importorskip("pyvista")
    import freecad_validator.render.render_freecad as r
    ...
```

## Verified outcomes

| Env | Before | After |
|---|---|---|
| No real FreeCAD (CI, default dev) | ❌ FAIL on \`import Mesh\` | ⏭️ SKIP |
| Real FreeCAD on \`PYTHONPATH\` | ✅ PASS | ✅ PASS |

Tested both locally:
- \`python -m pytest tests/unit/test_imports.py::test_render_module_imports -v\` → \`SKIPPED\`
- \`PYTHONPATH=/Applications/FreeCAD.app/Contents/Resources/lib python -m pytest tests/unit/test_imports.py::test_render_module_imports -v\` → \`PASSED\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)