### PR TITLE
fix: derive __version__ from package metadata

### DIFF
--- a/src/freecad_validator/__init__.py
+++ b/src/freecad_validator/__init__.py
@@ -15,6 +15,9 @@ Public API::
 """
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
 from freecad_validator.comparators.geometry import GeometryTolerances
 from freecad_validator.consistency.checker import SpecTolerances
 from freecad_validator.validator import CombineMethod, ValidationResult
@@ -27,4 +30,10 @@ __all__ = [
     "Validator",
     "ValidationResult",
 ]
-__version__ = "0.1.0"
+
+try:
+    # Track the version declared in pyproject.toml so we don't drift.
+    __version__ = _pkg_version("gnucleus-freecad-validator")
+except PackageNotFoundError:
+    # Running from a source checkout without an installed dist.
+    __version__ = "0.0.0+unknown"


### PR DESCRIPTION
## Summary

\`freecad_validator.__version__\` has been hardcoded to \`\"0.1.0\"\` and has drifted from \`pyproject.toml\` across every release since: \`0.1.1\`, \`0.1.2\`, \`0.1.3\` all shipped with \`__version__ == \"0.1.0\"\`.

Switch to \`importlib.metadata.version(\"gnucleus-freecad-validator\")\` so the runtime value tracks pyproject automatically and we don't have to remember to bump it twice on each release.

## Behavior

| Install state | \`__version__\` |
|---|---|
| Installed (\`pip install ...\` or \`pip install -e .\`) | actual version from package metadata |
| Source checkout, not installed | \`\"0.0.0+unknown\"\` |

## Test plan

- [x] After \`uv pip install -e .\` on this branch with pyproject at \`0.1.3\`: \`python -c 'import freecad_validator; print(freecad_validator.__version__)'\` → \`0.1.3\`.
- [x] \`pytest tests/unit/\` — 11 passed, 1 skipped (test_top_level_exports still asserts \`isinstance(__version__, str)\`).
- [x] \`ruff check src tests\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)