### PR TITLE
Docs/cli subcommands render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ htmlcov/
 # Sphinx / mkdocs
 site/
 _build/
+sample-data/

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ freecad-validator validate my_model.FCStd ground_truth.FCStd spec.json
 ```
 
 `freecad-validator` is the package's entry-point; `--help` shows
-`validate`, `batch`, and `join` subcommands.
+`validate`, `batch`, `join`, and `render` subcommands. (`render`
+rasterizes a `.FCStd` to a PNG and needs the optional `[render]`
+extra — see [Install](#install).)
 
 ### Python
 

--- a/SESSION_NOTES.md
+++ b/SESSION_NOTES.md
@@ -1,0 +1,39 @@
+# Session Handoff — CAD Bench contributions (Area 3: leaderboard run analysis)
+_2026-07-22_
+
+## Project
+Patrick is contributing to the Parametric CAD Bench (cadbench.ai, gNucleus-AI org). Three contribution areas from a 2026-07-14 meeting with Mei Chen (yicong2005@gmail.com): (1) freecad-validator improvements, (2) leaderboard agent+model entries, (3) analysis of published leaderboard runs. This session completed **Area 3** end-to-end.
+
+## What We Did
+- Mapped the ecosystem: scorer = `gNucleus-AI/freecad-validator` (this repo is Patrick's fork, PRs #9/#10 already merged), submissions = `gNucleus-AI/cad-bench-submission` (harbor run → HF dataset → manifest YAML PR), data = HF `gnucleus-ai/cad-gen-freecad` (100 task specs) + `gnucleus-ai/cad-gen-freecad-bench` (1,000-row results parquet + full per-trial artifacts under `runs/<agent>/<model>/<task>/`)
+- Analyzed all 1,000 trials (10 combos × 100 tasks, bench run 2026-05-13); sampled generated `answer.py` artifacts for the spur-gear task `freecad-08d2da3057` across 4 combos
+- Built an interactive HTML report (5 SVG charts, leaderboard table) and published as artifact: **https://claude.ai/code/artifact/957613b4-3cbf-4467-8501-c64a906d55f9**
+- Rendered the report to PDF via headless Chrome → **`~/cad-bench-analysis.pdf`** (8 pages, verified visually, one scatter-label collision fixed)
+- Tooling: Claude Code 2.1.218 + Opus 4.8 (1M) — Patrick wants this credited in his email to Mei
+
+## Key Findings (the deliverable's content)
+1. Outcomes are bimodal: 279/1000 trials at exactly 1.0, 166 at exactly 0
+2. 36/100 tasks are "toothed" (gear/spline/bearing/brake) and decide the ranking; top-5 combos near-tied on the other 64
+3. gemini-cli+gemini-pro alone has no gear penalty — it uses FreeCAD's built-in `InvoluteGearFeature`; others hand-roll involute math (verified on 1 task only — flagged as a caveat)
+4. Sonnet's #7 rank is a harness artifact: plain-part score 0.7136 ≈ Opus's 0.7138; deficit = 22 exceptions/21 near-timeout runs, 16 on gears
+5. 166 zeros decompose: 63 no-.FCStd-saved (gemini-cli signature), 99 structurally-gated (mini-swe signature), 4 exception-after-save; plus 102 trials spec=1.0 but geom<0.3 (47 hex nuts)
+6. 16× spread in pts/$; mini-swe+opus-4-7 = value sweet spot (88% of top score, 18% of cost)
+7. mini-swe uses 54–56k median input tokens vs 259–693k for vendor CLIs; codex shows adaptive effort (r=−0.49 runtime↔score)
+
+## Important Decisions
+- **Recommended Area 1 next**: `scripts/fetch_dataset.py` + Dockerfile PRs (glue code already exists from SETUP_NOTES.md work); Patrick hasn't picked a track for follow-up yet
+- **Toothed definition**: task name contains gear/spline/bearing/brake → 36 tasks (documented in report footer)
+- **Zero-cause categories** mutually exclusive, priority: missing artifact → exception → structural gate
+
+## Files and Components
+- `~/cad-bench-analysis.pdf` — final PDF deliverable (persists)
+- Artifact URL above — same report, interactive; updating it from a new session requires passing `url:` to the Artifact tool
+- **Scratchpad (EPHEMERAL — gone next session)**: `explore.py`, `explore2.py`, `chartdata.json`, `cad-bench-analysis.html`, venv, both parquets. To reproduce: re-download parquets from the two HF datasets (curl -L the `resolve/main/...` URLs), `python3 -m venv` + pandas/pyarrow (system Python 3.11, **no uv/conda/node on PATH**; Chrome at `/Applications/Google Chrome.app`)
+- `SETUP_NOTES.md` (this repo) — Patrick's earlier fork→run friction notes; contains the Area 1 roadmap
+
+## Current State
+- **Working**: Area 3 complete — report published + PDF delivered; all numbers verified against the parquet
+- **Partial**: Finding 3 (InvoluteGearFeature) verified on one task; a sweep of all 31 gear tasks' `answer.py` would harden it. Trajectory-level analysis (`trajectory.json` mining for save/verify rhythm, turn counts) proposed but not done
+- **TODO / open**: Patrick to email Mei (PDF + credit line ready). Next tracks: Area 1 PRs (fetch_dataset.py, Dockerfile, spec-scorer recoverability) or trajectory deep-dive or a cadbench news-post writeup
+- `gh` CLI is **not authenticated** — needed before opening PRs (`gh auth login`)
+- One oddity: first artifact republish hit a 409 "newer version from another session"; diff showed identical content, resolved by re-read + republish

--- a/SETUP_NOTES.md
+++ b/SETUP_NOTES.md
@@ -1,0 +1,130 @@
+# Setup Notes — gnucleus-freecad-validator
+
+Notes from a clean fork → clone → run pass on macOS, plus running sample
+validation jobs against the published [`cad-gen-freecad`](https://huggingface.co/datasets/gnucleus-ai/cad-gen-freecad)
+dataset. Captures the friction points worth smoothing for the next person.
+
+- **Environment:** macOS (Darwin 25.5.0, arm64), Python 3.11
+- **FreeCAD:** 1.1 (conda-forge build, module directly importable)
+- **Repo:** fork of `gNucleus-AI/freecad-validator` @ `main` (commit `74f2f47`)
+
+---
+
+## What worked smoothly
+
+- `from freecad_validator._freecad_loader import import_freecad` auto-detected
+  FreeCAD with no `FREECAD_LIB` wrangling — the conda-forge build is directly
+  importable, exactly as the README promises.
+- The CLI (`validate`, `batch`, `join`, `render`) installed cleanly via the
+  package entry-point and all subcommands resolved.
+- End-to-end scoring is fast and deterministic. Re-runs produced identical
+  scores.
+
+---
+
+## Friction points
+
+### 1. No Docker environment is provided
+The task brief assumes a "Build Docker environment" step, but the repo ships
+**no `Dockerfile`, `docker-compose.yml`, or `.devcontainer`**. FreeCAD is a
+heavy, platform-specific native dependency (LGPL, not pip-installable as a
+wheel), so a reference container would remove the single biggest setup
+variable. Today every user has to install FreeCAD by hand per-platform.
+
+> **Impact:** medium. Native FreeCAD install is the hardest part of setup; a
+> published image (e.g. `FROM continuumio/miniconda3` + `conda install -c
+> conda-forge freecad`) would make "clone and run" reproducible.
+
+### 2. No documented path from the published dataset → a runnable job
+This is the biggest gap. The README's "Inputs" section describes three inputs
+(`candidate.FCStd`, `reference.FCStd`, `spec.json` with `name` / `description`
+/ `key_parameters`), and the HuggingFace dataset publishes *exactly* those
+fields — but there is **no documented recipe or helper** to go from the
+dataset to the batch `sample-data/data/<case>/` layout the validator expects.
+
+I had to write glue myself:
+- read `data/dataset.parquet` (columns: `id`, `name`, `description`,
+  `key_parameters`, `image`, `fcstd_path`, `viewer_url`),
+- download each `fcstd/<id>.FCStd` asset,
+- emit `spec.json = {name, description, key_parameters}` per row,
+- lay them out as `sample-data/data/<id>/{candidate,reference}.FCStd + spec.json`.
+
+The `key_parameters` column is a markdown-bullet string (e.g.
+`- outer_diameter = 107.156mm`), which the rule-based spec parser *does*
+accept — but a one-paragraph "running against cad-gen-freecad" section (or a
+tiny `scripts/fetch_dataset.py`) would save every evaluator from
+rediscovering this.
+
+> **Impact:** high for anyone trying to reproduce benchmark numbers.
+
+### 3. README undercounts the CLI subcommands
+The Usage section states `--help` shows `validate`, `batch`, and `join` — but
+the CLI actually exposes **four**: `validate`, `batch`, `join`, **`render`**.
+The `render` subcommand was added (it rasterizes a `.FCStd` to PNG via the
+`[render]` extra) but the prose wasn't updated. Small, but it's the kind of
+drift that erodes trust in the docs.
+
+> **Fixed in the accompanying PR.**
+
+### 4. (Environmental) Python `urllib` SSL failure on macOS
+Downloading dataset assets with Python's `urllib.request` failed with
+`CERTIFICATE_VERIFY_FAILED: unable to get local issuer certificate`. This is
+the well-known macOS python.org-installer cert issue, not a repo bug —
+`curl`/`huggingface_hub` work fine. Noted only so the next person reaches for
+`curl` or `huggingface_hub` instead of burning time on it.
+
+---
+
+## Sample validation jobs (evidence)
+
+Built a 6-case `sample-data` dir from diverse dataset families (round mounting
+flange, spur gear, hex nut, smooth shaft, lego brick, cone frustum). Each case
+uses the dataset's ground-truth FCStd as **both** candidate and reference (a
+self-consistency sanity run) with its spec derived from the row.
+
+```
+$ freecad-validator batch --sample-data-dir ~/cad-data/sample
+validating 6 case(s) under ~/cad-data/sample/data
+[  1/6] 0603c53148  geom=1.000  spec=1.000  combined=1.000   # round mounting flange
+[  2/6] 08d2da3057  geom=1.000  spec=0.529  combined=0.692   # spur gear
+[  3/6] 5c60c7a001  geom=1.000  spec=1.000  combined=1.000   # hex nut
+[  4/6] 893b9137ff  geom=1.000  spec=1.000  combined=1.000   # smooth shaft
+[  5/6] aad4a0fbad  geom=1.000  spec=0.600  combined=0.750   # lego brick
+[  6/6] f3e10795e7  geom=1.000  spec=1.000  combined=1.000   # cone frustum
+
+validated: 6/6  errors: 0
+geometry_similarity : mean=1.000  median=1.000  min=1.000  max=1.000
+cad_spec_consistency: mean=0.855  median=1.000  min=0.529  max=1.000
+combined            : mean=0.907  median=1.000  min=0.692  max=1.000
+```
+
+Observations:
+- **Geometry self-match = 1.000 across all 6** — expected, validates the
+  geometry pass end-to-end.
+- **Spec consistency surfaces real signal** even on ground-truth models: the
+  spur gear scored 0.529 (9/17 consistent, 4 inconsistent, 4 not_found),
+  meaning several published `key_parameters` aren't recoverable from the
+  FCStd geometry by the current heuristics — a useful finding in itself.
+
+**Discrimination check** — cross-pairing a gear *candidate* against a flange
+*reference* correctly collapses geometry to 0:
+
+```
+$ freecad-validator validate gear/candidate.FCStd flange/reference.FCStd gear/spec.json
+geometry_similarity  : 0.000000
+geometry_similarity_reason : face count differs by 96% (candidate=185, reference=8;
+                             threshold 50%) — candidate likely represents a
+                             structurally different part; gated geometry to 0.0
+```
+
+So the scorer isn't trivially returning 1.0 — it gates structurally different
+parts to zero.
+
+---
+
+## Suggested follow-ups (beyond this PR)
+
+1. Add a `Dockerfile` (conda-forge FreeCAD base) for reproducible setup.
+2. Add a `scripts/fetch_dataset.py` + a README "Running against cad-gen-freecad"
+   section documenting the parquet → `sample-data` mapping.
+3. The accompanying PR fixes the subcommand miscount (#3 above).


### PR DESCRIPTION
[cad-bench-analysis.pdf](https://github.com/user-attachments/files/31201628/cad-bench-analysis.pdf)
Analysis of the existing agent run on the leaderboard.