### PR TITLE
docs: list the render subcommand in README CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ freecad-validator validate my_model.FCStd ground_truth.FCStd spec.json
 ```
 
 `freecad-validator` is the package's entry-point; `--help` shows
-`validate`, `batch`, and `join` subcommands.
+`validate`, `batch`, `join`, and `render` subcommands. (`render`
+rasterizes a `.FCStd` to a PNG and needs the optional `[render]`
+extra — see [Install](#install).)
 
 ### Python
 


### PR DESCRIPTION
`freecad-validator --help` exposes four subcommands (validate, batch, join, render), but the README's Usage section only listed the first three. The render subcommand was added (rasterize a .FCStd to PNG via the optional [render] extra) without updating the prose. Add it and point at the Install section for the extra.