### PR TITLE
feat: add placement validation API contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,29 @@ result.cad_spec_consistency   # spec ↔ CAD sub-score
 For repeated scoring, reuse one `Validator` across cases — its
 internal scorers amortize across calls.
 
+### Placement validation API contract
+
+The implementation-neutral placement API is available as a contract preview:
+
+```python
+from freecad_validator.placement import (
+    align_fcstd,
+    calculate_placement,
+    calculate_surface_coverage,
+    calculate_volumetric_iou,
+)
+
+aligned = align_fcstd("reference.FCStd", "candidate.FCStd")
+placement = calculate_placement(aligned)
+volume = calculate_volumetric_iou(aligned)
+surface = calculate_surface_coverage(aligned)
+```
+
+The public function signatures, immutable Pydantic configuration and result
+models, aligned-pair protocol, and exception hierarchy are stable contribution
+boundaries. Algorithm implementations are not included yet, so the four
+operations currently raise `NotImplementedError`.
+
 ## Scoring
 
 Two independent passes per case:

--- a/src/freecad_validator/placement/__init__.py
+++ b/src/freecad_validator/placement/__init__.py
@@ -1,0 +1,49 @@
+"""Implementation-neutral placement-validation API contract.
+
+The function bodies are contribution points. The public names, operation
+boundaries, serializable models, and failure semantics are defined here first
+so alignment and metric implementations can be authored independently.
+"""
+
+from freecad_validator.placement.alignment import AlignedFCStdPair, align_fcstd
+from freecad_validator.placement.errors import (
+    AlignmentError,
+    InvalidFCStdError,
+    MetricComputationError,
+    PlacementValidationError,
+)
+from freecad_validator.placement.models import (
+    AlignmentConfig,
+    AlignmentResult,
+    AxisAlignedBoundingBox,
+    PlacementConfig,
+    PlacementResult,
+    PlacementValidationResult,
+    SurfaceCoverageConfig,
+    SurfaceCoverageResult,
+    VolumetricIoUResult,
+)
+from freecad_validator.placement.placement import calculate_placement
+from freecad_validator.placement.surface import calculate_surface_coverage
+from freecad_validator.placement.volume import calculate_volumetric_iou
+
+__all__ = [
+    "AlignedFCStdPair",
+    "AlignmentConfig",
+    "AlignmentError",
+    "AlignmentResult",
+    "AxisAlignedBoundingBox",
+    "InvalidFCStdError",
+    "MetricComputationError",
+    "PlacementConfig",
+    "PlacementResult",
+    "PlacementValidationError",
+    "PlacementValidationResult",
+    "SurfaceCoverageConfig",
+    "SurfaceCoverageResult",
+    "VolumetricIoUResult",
+    "align_fcstd",
+    "calculate_placement",
+    "calculate_surface_coverage",
+    "calculate_volumetric_iou",
+]

--- a/src/freecad_validator/placement/alignment.py
+++ b/src/freecad_validator/placement/alignment.py
@@ -1,0 +1,54 @@
+"""Public rigid-alignment API contract for FCStd pairs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from freecad_validator.placement.models import AlignmentConfig, AlignmentResult
+
+
+@runtime_checkable
+class AlignedFCStdPair(Protocol):
+    """Opaque reusable context returned by :func:`align_fcstd`.
+
+    Implementations may cache FreeCAD shapes, samples, meshes, and native
+    alignment objects, but those objects are deliberately not public fields.
+    Metric functions must accept the context returned by the same
+    implementation of ``align_fcstd``.
+    """
+
+    @property
+    def reference_path(self) -> Path:
+        """Resolved reference FCStd path."""
+        ...
+
+    @property
+    def candidate_path(self) -> Path:
+        """Resolved candidate FCStd path."""
+        ...
+
+    @property
+    def alignment_result(self) -> AlignmentResult:
+        """Serializable transform and alignment diagnostics."""
+        ...
+
+
+def align_fcstd(
+    reference_fcstd: str | Path,
+    candidate_fcstd: str | Path,
+    config: AlignmentConfig | None = None,
+) -> AlignedFCStdPair:
+    """Load an FCStd pair and rigidly align candidate onto reference.
+
+    Contract:
+      * apply rotation and translation only; never scale, shear, or reflect;
+      * be deterministic for the same files and configuration;
+      * return an opaque context reusable by every metric call;
+      * raise ``InvalidFCStdError`` for invalid inputs and ``AlignmentError``
+        when a valid pair cannot be aligned.
+
+    The algorithm is intentionally unspecified so independent authors can
+    contribute implementations without changing the public API.
+    """
+    raise NotImplementedError("align_fcstd implementation has not been contributed")

--- a/src/freecad_validator/placement/errors.py
+++ b/src/freecad_validator/placement/errors.py
@@ -1,0 +1,17 @@
+"""Stable exceptions for placement-validation operation boundaries."""
+
+
+class PlacementValidationError(RuntimeError):
+    """Base exception for placement-validation operations."""
+
+
+class InvalidFCStdError(PlacementValidationError):
+    """An input file cannot provide valid geometry for the requested operation."""
+
+
+class AlignmentError(PlacementValidationError):
+    """A valid FCStd pair cannot be aligned under the configured constraints."""
+
+
+class MetricComputationError(PlacementValidationError):
+    """A metric cannot be computed from an otherwise valid aligned context."""

--- a/src/freecad_validator/placement/models.py
+++ b/src/freecad_validator/placement/models.py
@@ -1,0 +1,172 @@
+"""Serializable models for the placement-validation API contract.
+
+These models intentionally describe outputs, not implementation state. In
+particular, FreeCAD shapes, sampled points, meshes, and alignment-engine
+objects must remain private to an implementation of :class:`AlignedFCStdPair`.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
+
+FiniteFloat = Annotated[float, Field(allow_inf_nan=False)]
+NonNegativeFloat = Annotated[float, Field(ge=0.0, allow_inf_nan=False)]
+PositiveFloat = Annotated[float, Field(gt=0.0, allow_inf_nan=False)]
+UnitFloat = Annotated[float, Field(ge=0.0, le=1.0, allow_inf_nan=False)]
+Vector3 = tuple[FiniteFloat, FiniteFloat, FiniteFloat]
+RotationMatrix3 = tuple[Vector3, Vector3, Vector3]
+
+
+class APIModel(BaseModel):
+    """Common behavior for immutable, forward-compatible public records."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class AlignmentConfig(APIModel):
+    """Controls FCStd sampling and rigid SE(3) alignment only."""
+
+    sample_count: int = Field(default=6000, ge=128, strict=True)
+    tessellation_mm: PositiveFloat = 0.2
+    random_seed: int = Field(default=1729, ge=0, strict=True)
+    trim: FiniteFloat = Field(default=0.98, gt=0.0, le=1.0)
+    refine_top_k: int = Field(default=6, ge=1, strict=True)
+    max_refine_iterations: int = Field(default=40, ge=1, strict=True)
+
+
+class PlacementConfig(APIModel):
+    """Controls the percentile-deviation placement metric only."""
+
+    percentile: FiniteFloat = Field(default=98.0, ge=95.0, le=99.0)
+    matched_deviation_mm: NonNegativeFloat = 0.25
+    zero_score_deviation_mm: NonNegativeFloat = 5.0
+
+    @model_validator(mode="after")
+    def validate_score_thresholds(self) -> PlacementConfig:
+        if self.zero_score_deviation_mm <= self.matched_deviation_mm:
+            raise ValueError("zero_score_deviation_mm must exceed matched_deviation_mm")
+        return self
+
+
+class SurfaceCoverageConfig(APIModel):
+    """Controls tolerance-based bidirectional surface coverage."""
+
+    tolerance_relative_to_reference_bbox: FiniteFloat = Field(
+        default=0.01,
+        gt=0.0,
+    )
+
+
+class AlignmentResult(APIModel):
+    """Serializable rigid-alignment diagnostics.
+
+    The transform maps candidate coordinates into the reference coordinate
+    system as ``rotation @ candidate + translation_mm``. Scaling, reflection,
+    and shearing are outside this contract.
+    """
+
+    rotation: RotationMatrix3
+    translation_mm: Vector3
+    rmse_mm: NonNegativeFloat
+    normalized_rmse: NonNegativeFloat
+    identity_rmse_mm: NonNegativeFloat | None = None
+    details: dict[str, JsonValue] = Field(default_factory=dict)
+
+
+class PlacementResult(APIModel):
+    """Localized deviation score computed after the shared alignment."""
+
+    score: UnitFloat
+    percentile: FiniteFloat = Field(ge=95.0, le=99.0)
+    surface_deviation_mm: NonNegativeFloat
+    reference_to_candidate_deviation_mm: NonNegativeFloat
+    candidate_to_reference_deviation_mm: NonNegativeFloat
+    details: dict[str, JsonValue] = Field(default_factory=dict)
+
+
+class AxisAlignedBoundingBox(APIModel):
+    """Axis-aligned bounds in the aligned reference coordinate system."""
+
+    minimum_mm: Vector3
+    maximum_mm: Vector3
+
+    @model_validator(mode="after")
+    def validate_bounds(self) -> AxisAlignedBoundingBox:
+        if any(low > high for low, high in zip(self.minimum_mm, self.maximum_mm, strict=True)):
+            raise ValueError("minimum_mm must not exceed maximum_mm on any axis")
+        return self
+
+
+class VolumetricIoUResult(APIModel):
+    """Solid-volume Jaccard score and mismatch diagnostics.
+
+    Boolean failure is data, not an exception: implementations return
+    ``available=False``, ``iou=None``, and a non-empty ``error``. Invalid input
+    and alignment failures remain exceptions at the operation boundary.
+    """
+
+    available: bool = Field(strict=True)
+    iou: UnitFloat | None
+    reference_volume_mm3: NonNegativeFloat | None = None
+    candidate_volume_mm3: NonNegativeFloat | None = None
+    intersection_volume_mm3: NonNegativeFloat | None = None
+    union_volume_mm3: NonNegativeFloat | None = None
+    symmetric_difference_mm3: NonNegativeFloat | None = None
+    symmetric_difference_bbox: AxisAlignedBoundingBox | None = None
+    error: str | None = None
+    details: dict[str, JsonValue] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_availability(self) -> VolumetricIoUResult:
+        if self.available:
+            required = (
+                self.iou,
+                self.reference_volume_mm3,
+                self.candidate_volume_mm3,
+                self.intersection_volume_mm3,
+                self.union_volume_mm3,
+                self.symmetric_difference_mm3,
+            )
+            if any(value is None for value in required):
+                raise ValueError("available volumetric IoU requires all score and volume fields")
+            if self.error is not None:
+                raise ValueError("available volumetric IoU must not contain an error")
+        else:
+            if self.iou is not None:
+                raise ValueError("unavailable volumetric IoU must have iou=None")
+            if self.error is None or not self.error.strip():
+                raise ValueError("unavailable volumetric IoU requires an error")
+        return self
+
+
+class SurfaceCoverageResult(APIModel):
+    """Tolerance-based symmetric surface-coverage score.
+
+    ``score`` is the equal-direction average of ``reference_coverage`` and
+    ``candidate_coverage``. It is not a set-theoretic surface-area IoU.
+    """
+
+    score: UnitFloat
+    reference_coverage: UnitFloat
+    candidate_coverage: UnitFloat
+    tolerance_mm: PositiveFloat
+    details: dict[str, JsonValue] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_equal_direction_average(self) -> SurfaceCoverageResult:
+        expected = 0.5 * (self.reference_coverage + self.candidate_coverage)
+        if not math.isclose(self.score, expected, rel_tol=1.0e-12, abs_tol=1.0e-12):
+            raise ValueError("score must equal the average of both directional coverages")
+        return self
+
+
+class PlacementValidationResult(APIModel):
+    """All independently reported outputs from one aligned FCStd pair."""
+
+    alignment: AlignmentResult
+    placement: PlacementResult
+    volumetric_iou: VolumetricIoUResult
+    surface_coverage: SurfaceCoverageResult

--- a/src/freecad_validator/placement/placement.py
+++ b/src/freecad_validator/placement/placement.py
@@ -1,0 +1,19 @@
+"""Public localized-placement metric API contract."""
+
+from __future__ import annotations
+
+from freecad_validator.placement.alignment import AlignedFCStdPair
+from freecad_validator.placement.models import PlacementConfig, PlacementResult
+
+
+def calculate_placement(
+    aligned: AlignedFCStdPair,
+    config: PlacementConfig | None = None,
+) -> PlacementResult:
+    """Calculate only localized percentile deviation and its mapped score.
+
+    This operation must not realign the models, run FreeCAD Booleans, calculate
+    surface coverage, or aggregate any other score. Unexpected computation
+    failures raise ``MetricComputationError``.
+    """
+    raise NotImplementedError("calculate_placement implementation has not been contributed")

--- a/src/freecad_validator/placement/surface.py
+++ b/src/freecad_validator/placement/surface.py
@@ -1,0 +1,20 @@
+"""Public tolerance-based surface-coverage API contract."""
+
+from __future__ import annotations
+
+from freecad_validator.placement.alignment import AlignedFCStdPair
+from freecad_validator.placement.models import SurfaceCoverageConfig, SurfaceCoverageResult
+
+
+def calculate_surface_coverage(
+    aligned: AlignedFCStdPair,
+    config: SurfaceCoverageConfig | None = None,
+) -> SurfaceCoverageResult:
+    """Calculate bidirectional surface coverage after the shared alignment.
+
+    The score is the average of both directional coverage fractions under the
+    resolved distance tolerance. This operation must not realign the models or
+    claim to calculate a set-theoretic surface-area intersection-over-union.
+    Unexpected computation failures raise ``MetricComputationError``.
+    """
+    raise NotImplementedError("calculate_surface_coverage implementation has not been contributed")

--- a/src/freecad_validator/placement/volume.py
+++ b/src/freecad_validator/placement/volume.py
@@ -1,0 +1,18 @@
+"""Public volumetric-IoU API contract."""
+
+from __future__ import annotations
+
+from freecad_validator.placement.alignment import AlignedFCStdPair
+from freecad_validator.placement.models import VolumetricIoUResult
+
+
+def calculate_volumetric_iou(aligned: AlignedFCStdPair) -> VolumetricIoUResult:
+    """Calculate solid-volume Jaccard IoU after the shared alignment.
+
+    This operation must not realign the models or aggregate another score.
+    Normal FreeCAD Boolean failure is represented by
+    ``VolumetricIoUResult(available=False, ...)`` so batch callers retain the
+    other metrics. Invalid contexts and contract violations may raise
+    ``MetricComputationError``.
+    """
+    raise NotImplementedError("calculate_volumetric_iou implementation has not been contributed")

--- a/tests/unit/test_placement_api.py
+++ b/tests/unit/test_placement_api.py
@@ -1,0 +1,108 @@
+"""FreeCAD-free contract tests for placement validation."""
+
+from __future__ import annotations
+
+import pytest
+
+import freecad_validator.placement as placement_api
+
+EXPECTED_EXPORTS = {
+    "AlignedFCStdPair",
+    "AlignmentConfig",
+    "AlignmentError",
+    "AlignmentResult",
+    "AxisAlignedBoundingBox",
+    "InvalidFCStdError",
+    "MetricComputationError",
+    "PlacementConfig",
+    "PlacementResult",
+    "PlacementValidationError",
+    "PlacementValidationResult",
+    "SurfaceCoverageConfig",
+    "SurfaceCoverageResult",
+    "VolumetricIoUResult",
+    "align_fcstd",
+    "calculate_placement",
+    "calculate_surface_coverage",
+    "calculate_volumetric_iou",
+}
+
+
+def test_public_exports() -> None:
+    assert set(placement_api.__all__) == EXPECTED_EXPORTS
+
+
+def test_result_models_serialize_to_json_values() -> None:
+    alignment = placement_api.AlignmentResult(
+        rotation=((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)),
+        translation_mm=(0.0, 0.0, 0.0),
+        rmse_mm=0.1,
+        normalized_rmse=0.01,
+        identity_rmse_mm=1.0,
+        details={"backend": "contributor-defined"},
+    )
+    placement = placement_api.PlacementResult(
+        score=0.8,
+        percentile=98.0,
+        surface_deviation_mm=1.2,
+        reference_to_candidate_deviation_mm=1.0,
+        candidate_to_reference_deviation_mm=1.2,
+    )
+    volume = placement_api.VolumetricIoUResult(
+        available=False,
+        iou=None,
+        error="example Boolean failure",
+    )
+    surface = placement_api.SurfaceCoverageResult(
+        score=0.9,
+        reference_coverage=0.85,
+        candidate_coverage=0.95,
+        tolerance_mm=0.25,
+    )
+
+    result = placement_api.PlacementValidationResult(
+        alignment=alignment,
+        placement=placement,
+        volumetric_iou=volume,
+        surface_coverage=surface,
+    ).model_dump(mode="json")
+
+    assert result["placement"]["score"] == 0.8
+    assert result["volumetric_iou"]["iou"] is None
+
+
+def test_models_reject_contract_violations() -> None:
+    with pytest.raises(ValueError, match="zero_score_deviation_mm must exceed"):
+        placement_api.PlacementConfig(
+            matched_deviation_mm=1.0,
+            zero_score_deviation_mm=1.0,
+        )
+
+    with pytest.raises(ValueError):
+        placement_api.PlacementResult(
+            score=1.01,
+            percentile=98.0,
+            surface_deviation_mm=0.0,
+            reference_to_candidate_deviation_mm=0.0,
+            candidate_to_reference_deviation_mm=0.0,
+        )
+
+    with pytest.raises(ValueError, match="minimum_mm must not exceed"):
+        placement_api.AxisAlignedBoundingBox(
+            minimum_mm=(1.0, 0.0, 0.0),
+            maximum_mm=(0.0, 1.0, 1.0),
+        )
+
+
+def test_operations_are_explicitly_unimplemented() -> None:
+    with pytest.raises(NotImplementedError):
+        placement_api.align_fcstd("reference.FCStd", "candidate.FCStd")
+
+    aligned_context = object()
+    for operation in (
+        placement_api.calculate_placement,
+        placement_api.calculate_surface_coverage,
+        placement_api.calculate_volumetric_iou,
+    ):
+        with pytest.raises(NotImplementedError):
+            operation(aligned_context)


### PR DESCRIPTION
## Summary

- Add an implementation-neutral placement-validation contract under `freecad_validator.placement`.
- Define immutable Pydantic configuration and result models, stable exceptions, and an opaque aligned-pair protocol.
- Document the contract-preview import flow and add FreeCAD-free contract tests.

## Scope

- No placement or alignment algorithm implementation is included.
- The existing `Validator`, scorers, CLI, and combined-score behavior are unchanged.
- All operation entry points explicitly raise `NotImplementedError` until implementations are contributed.

## Validation

- `ruff format --check src/freecad_validator/placement tests/unit/test_placement_api.py`
- `ruff check --no-cache .`
- `pytest -p no:cacheprovider tests/unit` — 27 passed, 1 optional PyVista test skipped.
- Reviewed the branch changes for internal repository names, paths, infrastructure identifiers, credentials, private dataset references, and prototype implementation details; none were found.