### PR TITLE
Add deterministic FreeCAD/CalculiX FEM validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: install package + dev tools
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev]
+          pip install .[dev]
       - name: lint
         run: ruff check src tests
       - name: import smoke test
@@ -30,3 +30,24 @@ jobs:
         run: python -c "import freecad_validator; print(freecad_validator.__version__)"
       - name: pytest (FreeCAD-free unit tests only)
         run: pytest -m "not needs_freecad"
+
+  wheel-cross-interpreter:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        host-python: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.host-python }}
+      - name: install wheel under host Python
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          echo "FCSTD_ADAPTER_PATH=$(python -c 'from importlib.util import find_spec; from pathlib import Path; spec = find_spec("freecad_validator"); print(Path(next(iter(spec.submodule_search_locations))) / "fem" / "adapters" / "fcstd.py")')" >> "$GITHUB_ENV"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: execute installed adapter with embedded-Python equivalent
+        run: python tests/integration/check_fem_adapter_import.py "$FCSTD_ADAPTER_PATH"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,193 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,11 +200,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-
-
-   ----------------------------------------------------------------------
-
-   Copyright 2026 gNucleus AI
-
-   Full Apache License 2.0 text:
-   https://www.apache.org/licenses/LICENSE-2.0.txt

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # gnucleus-freecad-validator
 
-Heuristic geometry-similarity + spec-consistency scoring for FreeCAD parts.
-Deterministic, reproducible, no LLM, no GPU.
+Deterministic validation for FreeCAD CAD geometry, design specifications,
+placement, and solved FreeCAD/CalculiX FEM analyses. Reproducible, no LLM, no
+GPU.
 
 ## Prerequisites
 
@@ -164,6 +165,58 @@ models, aligned-pair protocol, and exception hierarchy are stable contribution
 boundaries. Algorithm implementations are not included yet, so the four
 operations currently raise `NotImplementedError`.
 
+### FEM validation
+
+The FEM API compares a candidate solved FCStd with an engineer-generated solved
+reference on a source STEP. It extracts the saved analysis, replays the
+candidate solve with CalculiX, verifies the stored displacement and stress
+fields, and returns a deterministic 0–100 report with validity gates and
+engineering diagnostics.
+
+```python
+from freecad_validator.fem import FEMValidator
+
+validator = FEMValidator(require_boolean=True)
+report = validator.validate(
+    step_path="source.step",
+    reference_fcstd="reference.FCStd",
+    candidate_fcstd="candidate.FCStd",
+)
+print(report.overall_score, report.grade, report.gates_triggered)
+```
+
+Trusted, already-extracted dictionaries can be scored without FreeCAD or CalculiX:
+
+```python
+from freecad_validator.fem import score_trusted_payloads
+
+report = score_trusted_payloads(target_geometry, reference_payload, candidate_payload)
+```
+
+This low-level function trusts adapter-produced replay-verification fields. Do
+not pass candidate-controlled JSON to it. Use `FEMValidator.validate()` for
+untrusted FCStd inputs so the validator performs extraction and solver replay.
+
+The equivalent CLI is:
+
+```bash
+freecad-validator fem-score source.step reference.FCStd candidate.FCStd \
+  --timeout 900 --json
+```
+
+Use `--require-boolean` only for tasks whose metadata explicitly requires a
+Boolean operation, and `--require-preprocessing` only when preprocessing is an
+explicit task requirement. Neither requirement is inferred from instruction
+text. Intermediate extraction JSON is temporary by default; pass
+`--extract-dir` to retain it.
+
+> [!WARNING]
+> FEM validation executes FreeCAD and CalculiX subprocesses against the
+> candidate document. Although the FCStd adapter rejects archive path
+> traversal before opening the file, untrusted submissions should still be
+> validated in a locked-down container with no network access and no sensitive
+> host mounts.
+
 ## Scoring
 
 Two independent passes per case:
@@ -298,3 +351,17 @@ Apache 2.0 — see [`LICENSE`](LICENSE).
 
 This project depends on [FreeCAD](https://www.freecad.org/), which is
 licensed under LGPL 2.1+. FreeCAD is not bundled with this package.
+
+Full FCStd FEM validation requires [CalculiX](https://www.calculix.de/), which is
+licensed under GPL 2.0 or later and is not bundled with this package. Install a
+`ccx` executable for the validator runtime, or configure `ccxBinaryPath` in
+FreeCAD's FEM preferences. The runtime preflight verifies FreeCAD, OCCT, the
+embedded Python, and CalculiX before candidate scoring; these versions are
+recorded in `ScoringReport.runtime_provenance`.
+
+- macOS: the official FreeCAD application includes `ccx` beside `freecadcmd`,
+  which the validator detects automatically.
+- Linux: install CalculiX with the system package manager and ensure `ccx` is
+  executable on `PATH`.
+- Windows: install a CalculiX executable and select it as `ccxBinaryPath` in
+  FreeCAD's FEM preferences.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gnucleus-freecad-validator"
-version = "0.1.3"
-description = "Validation tool for parameterized FreeCAD models. Given a design spec describing a CAD model's key parameters and a reference (ground-truth) .FCStd, the validator checks whether a candidate model is consistent with both the spec and the reference."
+version = "0.2.0"
+description = "Deterministic validation for FreeCAD geometry, design specifications, placement, and solved FreeCAD/CalculiX FEM analyses."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }
 authors = [{ name = "gNucleus AI" }]
-keywords = ["freecad", "cad", "validator", "benchmark", "spec", "geometry"]
+keywords = ["freecad", "cad", "fem", "fea", "calculix", "validator", "benchmark", "spec", "geometry"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -65,6 +65,7 @@ python_files = ["test_*.py"]
 addopts = "-ra --strict-markers"
 markers = [
     "needs_freecad: test requires the FreeCAD Python module to be importable",
+    "needs_calculix: test requires FreeCAD and CalculiX",
 ]
 
 

--- a/src/freecad_validator/__init__.py
+++ b/src/freecad_validator/__init__.py
@@ -1,7 +1,6 @@
-"""``gnucleus-freecad-validator`` — heuristic geometry-similarity +
-spec-consistency scoring for FreeCAD parts.
+"""Deterministic validation for FreeCAD CAD and FEM artifacts.
 
-Public API::
+The original geometry/spec API remains available at package level::
 
     from freecad_validator import Validator, ValidationResult
 
@@ -12,6 +11,9 @@ Public API::
         spec_json="path/to/spec.json",
     )
     print(result.combined, result.geometry_similarity, result.cad_spec_consistency)
+
+Placement protocols live under :mod:`freecad_validator.placement`, and solved
+FreeCAD/CalculiX FEM validation lives under :mod:`freecad_validator.fem`.
 """
 from __future__ import annotations
 

--- a/src/freecad_validator/_freecad_loader.py
+++ b/src/freecad_validator/_freecad_loader.py
@@ -20,10 +20,69 @@ location — that path is tried before any built-in candidate.
 from __future__ import annotations
 
 import os
+import shutil
 import sys
 import textwrap
 from collections.abc import Iterable
 from pathlib import Path
+
+
+def _resolve_executable(candidate: str | os.PathLike[str]) -> str | None:
+    """Return an absolute executable path for a path or command name."""
+    value = os.fspath(candidate)
+    resolved = shutil.which(value)
+    if resolved:
+        return str(Path(resolved).resolve())
+    path = Path(value).expanduser()
+    if path.is_file() and os.access(path, os.X_OK):
+        return str(path.resolve())
+    return None
+
+
+def resolve_freecad_command(
+    explicit: str | os.PathLike[str] | None = None,
+) -> str:
+    """Locate the FreeCAD 1.1 command-line executable.
+
+    ``explicit`` wins, followed by ``FREECAD_CMD``, the active conda
+    environment, ``PATH``, and common macOS/Windows application locations.
+    The returned value is always an absolute executable path.
+    """
+    requested = explicit or os.environ.get("FREECAD_CMD")
+    if requested:
+        resolved = _resolve_executable(requested)
+        if resolved:
+            return resolved
+        raise FileNotFoundError(
+            f"FreeCAD command {os.fspath(requested)!r} was not found or is not executable"
+        )
+
+    candidates: list[str | os.PathLike[str]] = []
+    conda_prefix = os.environ.get("CONDA_PREFIX")
+    if conda_prefix:
+        candidates.extend(
+            Path(conda_prefix) / "bin" / name
+            for name in ("freecadcmd", "FreeCADCmd")
+        )
+    candidates.extend(("freecadcmd", "FreeCADCmd"))
+    candidates.extend(
+        (
+            "/Applications/FreeCAD.app/Contents/Resources/bin/freecadcmd",
+            "/Applications/FreeCAD.app/Contents/MacOS/FreeCADCmd",
+        )
+    )
+    program_files = os.environ.get("ProgramFiles")
+    if program_files:
+        candidates.append(Path(program_files) / "FreeCAD 1.1" / "bin" / "FreeCADCmd.exe")
+
+    for candidate in candidates:
+        resolved = _resolve_executable(candidate)
+        if resolved:
+            return resolved
+    raise FileNotFoundError(
+        "FreeCAD's command-line executable could not be located. Install FreeCAD 1.1 "
+        "or set FREECAD_CMD to freecadcmd/FreeCADCmd."
+    )
 
 
 def _candidate_paths() -> Iterable[Path]:

--- a/src/freecad_validator/cli/main.py
+++ b/src/freecad_validator/cli/main.py
@@ -1,11 +1,12 @@
 """``freecad-validator`` CLI.
 
-Four subcommands::
+Five subcommands::
 
     freecad-validator validate CANDIDATE.FCStd REFERENCE.FCStd SPEC.json
     freecad-validator batch    --sample-data-dir <path>
     freecad-validator join     --candidate-dir <path> --reference-dir <path> --output-dir <path>
     freecad-validator render   INPUT.FCStd OUTPUT.png
+    freecad-validator fem-score SOURCE.step REFERENCE.FCStd CANDIDATE.FCStd
 
 The CLI is a thin wrapper over the public Python API
 (``freecad_validator.Validator``); every subcommand can be reproduced
@@ -26,6 +27,14 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from freecad_validator import Validator
+from freecad_validator.fem import FEMValidator
+from freecad_validator.fem.schema import (
+    DISP_TOL,
+    GROSS_TOL,
+    MESH_BUDGET_ZERO_RATIO,
+    STRESS_TOL,
+)
+from freecad_validator.fem.step_interface import DEFAULT_SUBPROCESS_TIMEOUT_SECONDS
 from freecad_validator.scorers.geometry import (
     add_tolerance_arguments,
     tolerances_from_args,
@@ -374,6 +383,69 @@ def _run_render(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# `fem-score` — replay and score one solved FreeCAD/CalculiX analysis
+# ---------------------------------------------------------------------------
+
+
+def _add_fem_score_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("step_path", help="source STEP geometry used by the FEM analysis")
+    p.add_argument("reference_fcstd", help="engineer-generated solved reference FCStd")
+    p.add_argument("candidate_fcstd", help="candidate solved FCStd to validate")
+    p.add_argument("--freecad-cmd", help="path or command name for FreeCAD 1.1.0 freecadcmd")
+    p.add_argument("--extract-dir", help="retain intermediate extraction JSON in this directory")
+    p.add_argument("--disp-tol", type=float, default=DISP_TOL,
+                   help="relative displacement/frequency tolerance")
+    p.add_argument("--stress-tol", type=float, default=STRESS_TOL,
+                   help="relative stress tolerance")
+    p.add_argument("--gross-tol", type=float, default=GROSS_TOL,
+                   help="critical-result relative-error validity gate")
+    p.add_argument("--mesh-budget-ratio", type=float, default=MESH_BUDGET_ZERO_RATIO,
+                   help="element-count ratio at which mesh-budget credit reaches zero")
+    p.add_argument("--require-preprocessing", action="store_true",
+                   help="require candidate geometry to differ from the raw STEP")
+    p.add_argument("--require-boolean", action="store_true",
+                   help="require the explicit minimum Boolean topology contract")
+    p.add_argument("--timeout", type=float, default=DEFAULT_SUBPROCESS_TIMEOUT_SECONDS,
+                   help="maximum seconds for each FreeCAD/CalculiX adapter process")
+    p.add_argument("--json", dest="emit_json", action="store_true",
+                   help="emit the full scoring report as JSON")
+    p.add_argument("--output-json", type=Path,
+                   help="also write the full scoring report to this path")
+
+
+def _run_fem_score(args: argparse.Namespace) -> int:
+    validator = FEMValidator(
+        freecad_cmd=args.freecad_cmd,
+        extract_dir=args.extract_dir,
+        displacement_tolerance=args.disp_tol,
+        stress_tolerance=args.stress_tol,
+        gross_error_tolerance=args.gross_tol,
+        mesh_budget_zero_ratio=args.mesh_budget_ratio,
+        require_preprocessing=args.require_preprocessing,
+        require_boolean=args.require_boolean,
+        timeout_seconds=args.timeout,
+    )
+    report = validator.validate(
+        step_path=args.step_path,
+        reference_fcstd=args.reference_fcstd,
+        candidate_fcstd=args.candidate_fcstd,
+    )
+    payload = report.to_dict()
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    if args.emit_json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(report.summary_line())
+        print(f"confidence={report.confidence} reproducibility={report.reproducibility_status}")
+        if report.gates_triggered:
+            reasons = sorted({gate["reason"] for gate in report.gates_triggered})
+            print("validity_gates=" + ",".join(reasons))
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # Top-level entry point
 # ---------------------------------------------------------------------------
 
@@ -387,6 +459,8 @@ _SUBCOMMANDS = (
      _add_join_args, _run_join),
     ("render", "rasterize a .FCStd to a PNG (requires `[render]` extra)",
      _add_render_args, _run_render),
+    ("fem-score", "replay and score a solved FreeCAD/CalculiX analysis",
+     _add_fem_score_args, _run_fem_score),
 )
 
 

--- a/src/freecad_validator/fem/__init__.py
+++ b/src/freecad_validator/fem/__init__.py
@@ -1,0 +1,51 @@
+"""Deterministic validation of solved FreeCAD/CalculiX FEM analyses.
+
+The scorer compares a candidate FCStd with an engineer-generated solved
+reference and can replay the candidate solve before accepting its stored result
+fields.
+"""
+
+from freecad_validator.fem.schema import (
+    CATEGORIES,
+    CRITICAL_GATES,
+    DEFAULT_WEIGHTS,
+    CaseDefinition,
+    FailureMode,
+    Finding,
+    ScoringReport,
+    Submission,
+    SubScore,
+    grade_from_score,
+)
+from freecad_validator.fem.scorer import score_result
+from freecad_validator.fem.step_interface import (
+    ExtractionError,
+    RuntimeEnvironmentError,
+    build_case,
+    score_step_fcstd,
+    score_trusted_payloads,
+)
+from freecad_validator.fem.validator import FEMValidator
+
+FEMScoringReport = ScoringReport
+
+__all__ = [
+    "CATEGORIES",
+    "CRITICAL_GATES",
+    "DEFAULT_WEIGHTS",
+    "CaseDefinition",
+    "ExtractionError",
+    "FEMScoringReport",
+    "FEMValidator",
+    "FailureMode",
+    "Finding",
+    "RuntimeEnvironmentError",
+    "ScoringReport",
+    "Submission",
+    "SubScore",
+    "build_case",
+    "grade_from_score",
+    "score_result",
+    "score_step_fcstd",
+    "score_trusted_payloads",
+]

--- a/src/freecad_validator/fem/adapters/__init__.py
+++ b/src/freecad_validator/fem/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Scripts executed by FreeCAD's command-line interpreter.
+
+The modules are intentionally not imported here because FreeCAD invokes each
+script as an entry point and does not provide normal ``__main__`` semantics.
+"""

--- a/src/freecad_validator/fem/adapters/fcstd.py
+++ b/src/freecad_validator/fem/adapters/fcstd.py
@@ -1,0 +1,684 @@
+"""Extract a FreeCAD FEM result document (.FCStd) into the scorer's JSON schema.
+
+MUST be run under a FEM-enabled FreeCAD 1.1.0 interpreter compatible with the
+files being compared. For example:
+
+    freecadcmd fcstd.py <input.FCStd> <output.json>
+
+It reads the saved result object (the same object FreeCAD_FEM_Workflow.py writes
+its summary from) plus the material, constraints, solver and mesh, and writes a
+dict that maps onto ``freecad_validator.fem.schema``. The JSON is
+written to a FILE, so FreeCAD's banner/warning noise on stdout never corrupts it.
+
+Notes
+-----
+* freecadcmd does not set __name__ == "__main__" and passes script args through
+  sys.argv, so the entry point is called unconditionally at the bottom and args
+  are discovered by extension (.FCStd / .json) rather than by position.
+* An .FCStd carries geometry, material, BCs/loads, mesh and nodal result fields,
+  but those arrays alone do not prove a solver ran. Candidate extraction uses
+  ``verify-solve`` to rerun CalculiX from the saved analysis and compare the
+  replayed fields before setting solver/artifact evidence. Reference extraction
+  stays read-only and never vouches for candidate convergence.
+"""
+
+import ctypes
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+def preload_openmp_runtime():
+    resources_dir = os.path.dirname(os.path.dirname(sys.executable))
+    libomp = os.path.join(resources_dir, "lib", "libomp.dylib")
+    if not os.path.exists(libomp):
+        return
+    try:
+        ctypes.CDLL(libomp, mode=ctypes.RTLD_GLOBAL)
+    except OSError:
+        return
+
+
+preload_openmp_runtime()
+
+import FreeCAD  # noqa: E402
+from femtools.ccxtools import FemToolsCcx  # noqa: E402
+from FreeCAD import Units  # noqa: E402
+
+# FreeCAD may embed a different Python minor version from the interpreter that
+# installed this wheel. Loading this pure-Python module by file path avoids
+# importing the package root and any host-interpreter extension modules.
+replay_path = Path(__file__).resolve().parents[1] / "replay_compare.py"
+replay_spec = importlib.util.spec_from_file_location(
+    "_freecad_validator_replay_compare", replay_path
+)
+if replay_spec is None or replay_spec.loader is None:
+    raise ImportError(f"cannot load replay comparison module from {replay_path}")
+replay_compare = importlib.util.module_from_spec(replay_spec)
+replay_spec.loader.exec_module(replay_compare)
+
+REPLAY_REL_TOL = replay_compare.REPLAY_REL_TOL
+REPLAY_SCALAR_FIELDS = replay_compare.REPLAY_SCALAR_FIELDS
+compare_result_snapshots = replay_compare.compare_result_snapshots
+select_scored_results = replay_compare.select_scored_results
+
+
+def runtime_info(require_calculix=False):
+    """Return runtime versions and optionally verify the configured solver."""
+    import Part
+
+    freecad_version = ".".join(str(value) for value in FreeCAD.Version()[:3])
+    info = {
+        "freecad": freecad_version,
+        "freecad_build": list(FreeCAD.Version()),
+        "occt": str(Part.OCC_VERSION),
+        "python": sys.version.split()[0],
+    }
+    if not require_calculix:
+        return info
+
+    configured = FreeCAD.ParamGet(
+        "User parameter:BaseApp/Preferences/Mod/Fem/Ccx"
+    ).GetString("ccxBinaryPath", "")
+    ccx = shutil.which(configured or "ccx")
+    if ccx is None:
+        sibling = Path(sys.executable).resolve().with_name("ccx")
+        ccx = str(sibling) if sibling.is_file() and os.access(sibling, os.X_OK) else None
+    if ccx is None:
+        raise RuntimeError(
+            "CalculiX executable was not found; install ccx or configure its path "
+            "in FreeCAD FEM preferences"
+        )
+    completed = subprocess.run(
+        [ccx, "-v"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    version_output = "\n".join(
+        part for part in (completed.stdout, completed.stderr) if part
+    )
+    version_match = re.search(r"Version\s+([0-9]+(?:\.[0-9]+)+)", version_output)
+    # Some CalculiX builds return a non-zero status after printing their version.
+    # A successfully parsed version is the portable availability check.
+    if version_match is None:
+        raise RuntimeError("CalculiX executable failed its version preflight")
+    info["calculix"] = version_match.group(1)
+    info["calculix_executable"] = Path(ccx).name
+    return info
+
+
+def qty(value, unit):
+    """Convert a FreeCAD quantity/string/number to a float in `unit`."""
+    try:
+        return float(Units.Quantity(value).getValueAs(unit))
+    except (ValueError, TypeError):
+        return float(value)
+
+
+def _is_result_object(obj):
+    """A loaded mechanical FEM result (has nodal fields). Single source of truth
+    for what counts as a 'result', shared by discovery, the pre-replay purge and
+    replay-output selection so they can never disagree (a disagreement would be a
+    hole: a result invisible to the purge but visible to selection)."""
+    return obj.TypeId == "Fem::FemResultObjectPython" and getattr(obj, "NodeNumbers", None)
+
+
+def find_result(doc):
+    for o in doc.Objects:
+        if _is_result_object(o):
+            return o
+    return None
+
+
+def extract_result_values(res):
+    results = {}
+    disp = list(getattr(res, "DisplacementLengths", []) or [])
+    vm = list(getattr(res, "vonMises", []) or [])
+    shear = list(getattr(res, "MaxShear", []) or [])
+    temp = list(getattr(res, "Temperature", []) or [])
+    if disp:
+        results["max_displacement_mm"] = max(disp)
+        results["mean_displacement_mm"] = sum(disp) / len(disp)
+    if vm:
+        results["max_von_mises_MPa"] = max(vm)
+        results["mean_von_mises_MPa"] = sum(vm) / len(vm)
+    if shear:
+        results["max_shear_MPa"] = max(shear)
+    if temp:
+        results["max_temperature_C"] = max(temp)
+    freqs = list(getattr(res, "EigenmodeFrequencies", []) or [])
+    if freqs:
+        results["natural_frequencies_Hz"] = freqs
+    return results
+
+
+def snapshot_result_fields(res):
+    fields = {}
+    for name in REPLAY_SCALAR_FIELDS:
+        values = list(getattr(res, name, []) or [])
+        if values:
+            fields[name] = [float(value) for value in values]
+
+    vectors = list(getattr(res, "DisplacementVectors", []) or [])
+    if vectors:
+        fields["DisplacementVectors"] = [
+            (float(value.x), float(value.y), float(value.z)) for value in vectors
+        ]
+
+    return {
+        "node_numbers": [int(node) for node in list(getattr(res, "NodeNumbers", []) or [])],
+        "fields": fields,
+    }
+
+
+def find_replay_context(doc, result, solved_node_count):
+    analyses = [obj for obj in doc.Objects if obj.TypeId == "Fem::FemAnalysis"]
+    matching_analyses = []
+    for analysis in analyses:
+        group = list(getattr(analysis, "Group", []) or [])
+        if result in group or getattr(result, "Mesh", None) in group:
+            matching_analyses.append(analysis)
+    if len(matching_analyses) != 1:
+        raise RuntimeError(
+            "stored FEM result is not owned by exactly one analysis "
+            f"(found {len(matching_analyses)})"
+        )
+
+    analysis = matching_analyses[0]
+    group = list(getattr(analysis, "Group", []) or [])
+    solvers = [obj for obj in group if "Solver" in obj.TypeId or "Ccx" in obj.TypeId]
+    if len(solvers) != 1:
+        raise RuntimeError(
+            f"analysis must contain exactly one solver for replay (found {len(solvers)})"
+        )
+
+    source_meshes = []
+    for obj in group:
+        fem_mesh = getattr(obj, "FemMesh", None)
+        node_count = getattr(fem_mesh, "NodeCount", 0) if fem_mesh is not None else 0
+        if "FemMeshShape" in obj.TypeId and node_count == solved_node_count:
+            source_meshes.append(obj)
+    if len(source_meshes) != 1:
+        raise RuntimeError(
+            "analysis must contain exactly one source mesh matching the stored result "
+            f"({solved_node_count} nodes; found {len(source_meshes)})"
+        )
+    return analysis, solvers[0], source_meshes[0]
+
+
+def verify_solver_replay(doc, stored_result, analysis_type, output_path):
+    stored_snapshot = snapshot_result_fields(stored_result)
+    work_parent = os.path.dirname(os.path.abspath(output_path))
+    work_dir = tempfile.mkdtemp(prefix="fem-replay-", dir=work_parent)
+    os.chmod(work_dir, 0o700)
+    try:
+        analysis, solver, source_mesh = find_replay_context(
+            doc, stored_result, len(stored_snapshot["node_numbers"])
+        )
+        solver.WorkingDir = work_dir
+        fea = FemToolsCcx(analysis, solver)
+        fea.update_objects()
+        fea.setup_working_dir(work_dir, create=True)
+        fea.setup_ccx()
+        prerequisite_error = fea.check_prerequisites()
+        if prerequisite_error:
+            raise RuntimeError(f"CalculiX replay prerequisites failed: {prerequisite_error}")
+
+        # Clear every existing result before re-solving. FreeCAD's helper removes
+        # analysis-group members, while documents can also contain detached result
+        # objects. Removing both makes the freshly loaded replay result unambiguous.
+        fea.purge_results()
+        for stale in [obj for obj in doc.Objects if _is_result_object(obj)]:
+            doc.removeObject(stale.Name)
+        doc.recompute()
+        fea.write_inp_file()
+        return_code = fea.ccx_run()
+        if return_code not in (None, 0):
+            raise RuntimeError(f"CalculiX replay failed with exit code {return_code}")
+        fea.load_results()
+        doc.recompute()
+
+        replay_results = [obj for obj in doc.Objects if _is_result_object(obj)]
+        if not replay_results:
+            raise RuntimeError("CalculiX replay produced no loaded FEM result")
+        replayed_result = max(replay_results, key=lambda obj: len(obj.NodeNumbers))
+        replayed_snapshot = snapshot_result_fields(replayed_result)
+        verification = compare_result_snapshots(
+            stored_snapshot, replayed_snapshot, analysis_type
+        )
+        verification.update({
+            "analysis": analysis.Name,
+            "solver": solver.Name,
+            "mesh": source_mesh.Name,
+            "node_count": len(replayed_snapshot["node_numbers"]),
+        })
+        return verification, extract_result_values(replayed_result)
+    except Exception as exc:
+        return {
+            "passed": False,
+            "status": "solve_failed",
+            "relative_tolerance": REPLAY_REL_TOL,
+            "failures": [str(exc)],
+            "field_comparisons": {},
+        }, None
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+def extract_material(doc):
+    for o in doc.Objects:
+        if "Material" in o.TypeId and getattr(o, "Material", None):
+            m = dict(o.Material)
+            out = {"name": m.get("Name", "")}
+            if m.get("YoungsModulus"):
+                out["E_MPa"] = qty(m["YoungsModulus"], "MPa")
+            if m.get("PoissonRatio"):
+                out["nu"] = float(m["PoissonRatio"])
+            if m.get("Density"):
+                out["rho_kg_m3"] = qty(m["Density"], "kg/m^3")
+            return out
+    return {}
+
+
+# CalculiX/ccxtools AnalysisType string -> scorer vocabulary
+_ANALYSIS = {"static": "static", "frequency": "modal", "thermomech": "thermal_mechanical",
+             "buckling": "buckling", "check": "static"}
+
+
+def extract_solver(doc):
+    for o in doc.Objects:
+        if "Solver" in o.TypeId or "Ccx" in o.TypeId:
+            at = getattr(o, "AnalysisType", "static")
+            return _ANALYSIS.get(str(at), "static"), getattr(o, "GeometricalNonlinearity", "linear")
+    return "static", "linear"
+
+
+def refs_str(o):
+    try:
+        return "; ".join(f"{r[0].Name}/{','.join(r[1])}" for r in o.References)
+    except Exception:
+        return ""
+
+
+def force_direction(o):
+    """Unit direction the force actually points, or None.
+
+    Lets the scorer check WHICH WAY the load points, not just its magnitude.
+    DirectionVector is already the FINAL applied direction: the CalculiX writer
+    (Mod/Fem/femsolver/calculix/write_constraint_force.py) forms the nodal load
+    straight from DirectionVector and never references `Reversed`, so we must NOT
+    negate it here. A load written as (DirectionVector, Reversed=True) is
+    physically identical to the same DirectionVector with Reversed=False; the
+    solved displacement field confirms CalculiX ignores `Reversed`."""
+    dv = getattr(o, "DirectionVector", None)
+    if dv is None or getattr(dv, "Length", 0) < 1e-9:
+        return None
+    u = FreeCAD.Vector(dv)
+    u.normalize()
+    return [u.x, u.y, u.z]
+
+
+def refs_centroid(o):
+    """Area/length-weighted centroid (mm) of the loaded sub-elements, or None.
+
+    Both reference and candidate are built on the same source solid, so this point is
+    comparable even when their internal face/edge indices differ - it lets the
+    scorer check WHERE the load is applied without relying on reference names."""
+    pts, wts = [], []
+    try:
+        for obj, subs in o.References:
+            shp = getattr(obj, "Shape", None)
+            if shp is None:
+                continue
+            for sub in (subs or [None]):
+                el = shp.getElement(sub) if sub else shp
+                c = el.CenterOfMass
+                w = getattr(el, "Area", None) or getattr(el, "Length", None) or 1.0
+                pts.append((c.x, c.y, c.z))
+                wts.append(float(w))
+    except Exception:
+        return None
+    if not pts:
+        return None
+    tw = sum(wts) or 1.0
+    return [sum(p[i] * w for p, w in zip(pts, wts, strict=True)) / tw for i in range(3)]
+
+
+def extract_bcs_loads(doc):
+    bcs, loads = [], []
+    for o in doc.Objects:
+        t = o.TypeId
+        if t in ("Fem::ConstraintFixed", "Fem::ConstraintDisplacement"):
+            bcs.append({"type": "fixed", "location": refs_str(o)})
+        elif t in ("Fem::ConstraintBearing",):
+            bcs.append({"type": "support", "location": refs_str(o)})
+        elif t == "Fem::ConstraintForce":
+            loads.append({"type": "force", "magnitude_N": qty(o.Force, "N"),
+                          "reversed": bool(getattr(o, "Reversed", False)),
+                          "direction": force_direction(o), "centroid": refs_centroid(o),
+                          "location": refs_str(o)})
+        elif t == "Fem::ConstraintPressure":
+            loads.append({"type": "pressure", "magnitude_Pa": qty(o.Pressure, "Pa"),
+                          "magnitude_N": 0, "reversed": bool(getattr(o, "Reversed", False)),
+                          "centroid": refs_centroid(o), "location": refs_str(o)})
+        elif t == "Fem::ConstraintSelfWeight":
+            loads.append({"type": "self_weight", "magnitude_N": 0})
+    return bcs, loads
+
+
+def _topo(x):
+    """A Part TopoShape from either a TopoShape or a document object, else None."""
+    if x is None:
+        return None
+    if getattr(x, "Solids", None) is not None:   # already a TopoShape (has .Solids)
+        return x
+    return getattr(x, "Shape", None)             # a document object -> its shape
+
+
+def analysed_solids(doc):
+    """The solid shape(s) that make up the analysed geometry, as a list.
+
+    The geometry-fidelity check compares the analysed volume to the STEP's TOTAL
+    volume, so for a multi-body part we must return EVERY analysed solid (their
+    volumes are summed by the caller), not just one - while never counting leftover
+    imported sub-parts or a fusion's consumed inputs (that would double-count).
+    Priority:
+      1) the geometry the FEM mesh was generated on (mesh object's Part/Shape link)
+         - exactly what was meshed; a compound reports all its solids, so this is
+           correct for one solid, a fusion, or a multi-solid compound;
+      2) the DISTINCT bodies referenced by the analysis constraints (BCs/loads) -
+         robust for a disjoint multi-body assembly and immune to leftover sub-parts,
+         because only the bodies actually constrained/loaded are counted;
+      3) the single largest-volume solid object - last resort (single-body only).
+    """
+    # 1) meshed geometry (one object, possibly a compound of several solids)
+    for o in doc.Objects:
+        if "FemMeshShape" in o.TypeId or "FemMeshGmsh" in o.TypeId:
+            shp = _topo(getattr(o, "Part", None)) or _topo(getattr(o, "Shape", None))
+            if shp is not None and getattr(shp, "Solids", None):
+                return [shp]
+    # 2) the distinct bodies the analysis constraints reference
+    refd = {}
+    for o in doc.Objects:
+        if not o.TypeId.startswith("Fem::Constraint"):
+            continue
+        try:
+            refs = o.References or []
+        except Exception:
+            refs = []
+        for parent, _subs in refs:
+            shp = getattr(parent, "Shape", None)
+            if shp is not None and getattr(shp, "Solids", None):
+                refd[getattr(parent, "Name", id(parent))] = shp
+    if refd:
+        return list(refd.values())
+    # 3) the single largest-volume solid object
+    best, best_vol = None, 0.0
+    for o in doc.Objects:
+        shp = getattr(o, "Shape", None)
+        if shp is not None and getattr(shp, "Solids", None) and shp.Volume > best_vol:
+            best, best_vol = shp, shp.Volume
+    return [best] if best is not None else []
+
+
+def extract_geometry(doc):
+    shapes = analysed_solids(doc)
+    if not shapes:
+        return {}
+    solids = [solid for shape in shapes for solid in shape.Solids]
+    volume = sum(s.Volume for s in shapes)
+    surface_area = sum(s.Area for s in shapes)
+    regions = sorted(
+        (
+            {
+                "volume_mm3": solid.Volume,
+                "surface_area_mm2": solid.Area,
+                "num_faces": len(solid.Faces),
+                "num_edges": len(solid.Edges),
+                "num_shells": len(solid.Shells),
+            }
+            for solid in solids
+        ),
+        key=lambda region: (
+            region["volume_mm3"],
+            region["surface_area_mm2"],
+            region["num_faces"],
+            region["num_edges"],
+        ),
+    )
+    bbs = [s.BoundBox for s in shapes]
+    xs = [b.XMin for b in bbs] + [b.XMax for b in bbs]
+    ys = [b.YMin for b in bbs] + [b.YMax for b in bbs]
+    zs = [b.ZMin for b in bbs] + [b.ZMax for b in bbs]
+    dx, dy, dz = max(xs) - min(xs), max(ys) - min(ys), max(zs) - min(zs)
+    return {"characteristic_length_mm": (dx * dx + dy * dy + dz * dz) ** 0.5,
+            "bbox_mm": [dx, dy, dz], "volume_mm3": volume,
+            "surface_area_mm2": surface_area,
+            "num_solids": len(solids),
+            "num_compsolids": sum(len(shape.CompSolids) for shape in shapes),
+            "shape_types": sorted({str(shape.ShapeType) for shape in shapes}),
+            "num_faces": sum(region["num_faces"] for region in regions),
+            "num_edges": sum(region["num_edges"] for region in regions),
+            "regions": regions}
+
+
+def assert_safe_fcstd(path):
+    """Reject an FCStd whose zip embeds a path-traversal member (zip-slip).
+
+    Included files may otherwise be extracted outside the intended directory
+    when FreeCAD opens the document. Validate every member before opening it:
+    absolute paths, drive letters, and ``..`` components that escape the archive
+    root are rejected. Legitimate FCStd members use relative paths."""
+    try:
+        with zipfile.ZipFile(path) as zf:
+            names = zf.namelist()
+    except zipfile.BadZipFile:
+        return  # not a zip (unlikely for .FCStd); openDocument will handle it
+    for name in names:
+        norm = name.replace("\\", "/")
+        if norm.startswith("/") or (len(norm) > 1 and norm[1] == ":"):
+            raise SystemExit(f"[fcstd_adapter] SECURITY: absolute path in FCStd zip member: {name!r}")
+        parts = [p for p in norm.split("/") if p not in ("", ".")]
+        depth = 0
+        for p in parts:
+            depth += -1 if p == ".." else 1
+            if depth < 0:
+                raise SystemExit(f"[fcstd_adapter] SECURITY: path traversal in FCStd zip member: {name!r}")
+
+
+def main():
+    args = sys.argv
+    import_check = "import-check" in args
+    verify_solve = "verify-solve" in args
+    geometry_only = "geometry-only" in args
+    runtime_only = "runtime-info" in args
+    fcstd = next((a for a in args if a.lower().endswith(".fcstd")), None)
+    outs = [a for a in args if a.lower().endswith(".json")]
+    if import_check:
+        print("[fcstd_adapter] pure replay module loaded")
+        return
+    if runtime_only:
+        if not outs:
+            raise SystemExit("runtime-info requires an output JSON path")
+        with open(outs[0], "w", encoding="utf-8") as fh:
+            json.dump({"runtime": runtime_info(require_calculix=True)}, fh, indent=2)
+        print(f"[fcstd_adapter] wrote {outs[0]}  runtime_info=true")
+        return
+    if not fcstd:
+        raise SystemExit("usage: freecadcmd fcstd_adapter.py <input.FCStd> <output.json>")
+    out = outs[0] if outs else os.path.splitext(fcstd)[0] + ".scorer.json"
+
+    assert_safe_fcstd(fcstd)
+    doc = FreeCAD.openDocument(fcstd)
+    if geometry_only:
+        out_dict = {
+            "source_fcstd": os.path.basename(fcstd),
+            "geometry": extract_geometry(doc),
+            "runtime": runtime_info(),
+        }
+        with open(out, "w", encoding="utf-8") as fh:
+            json.dump(out_dict, fh, indent=2)
+        FreeCAD.closeDocument(doc.Name)
+        print(f"[fcstd_adapter] wrote {out}  geometry_only=true")
+        return
+    res = find_result(doc)
+    if res is None:
+        failure_reason = f"no FEM result object found in {fcstd}"
+        out_dict = {
+            "source_fcstd": os.path.basename(fcstd),
+            "no_result": True,
+            "extraction_error": failure_reason,
+            "solver": {"converged": False},
+            "results": {},
+            "artifacts": {},
+            "runtime": runtime_info(),
+        }
+        with open(out, "w", encoding="utf-8") as fh:
+            json.dump(out_dict, fh, indent=2)
+        FreeCAD.closeDocument(doc.Name)
+        print(f"[fcstd_adapter] wrote {out}  no_result=true")
+        return
+
+    analysis, nonlinearity = extract_solver(doc)
+    bcs, loads = extract_bcs_loads(doc)
+    material = extract_material(doc)
+    geometry = extract_geometry(doc)
+
+    results = extract_result_values(res)
+    disp = list(getattr(res, "DisplacementLengths", []) or [])
+
+    # Mesh stats for the mesh-budget category. CRITICAL: tie the reported mesh to
+    # the SOLVE, not to whatever mesh is attached to the result. A genuine result
+    # carries exactly one displacement value per mesh node, so the mesh actually
+    # solved on is the one whose NodeCount == len(DisplacementLengths). Reading
+    # Reading res.Mesh alone can select a mesh that differs from the one used for
+    # the stored result, so choose the mesh that
+    # matches the displacement field (searching every mesh in the document, not
+    # just res.Mesh) and treat the result as incoherent when, for a displacement
+    # analysis, no mesh matches it.
+    n_solved = len(disp)
+    solved_fm = None
+    # search every mesh in the document, plus the result's own attached mesh (so we
+    # do not depend on res.Mesh also being enumerated in doc.Objects)
+    mesh_candidates = list(doc.Objects)
+    if getattr(res, "Mesh", None) is not None:
+        mesh_candidates.append(res.Mesh)
+    for o in mesh_candidates:
+        cand_fm = getattr(o, "FemMesh", None)
+        nc = getattr(cand_fm, "NodeCount", 0) if cand_fm is not None else 0
+        if not nc:
+            continue
+        if n_solved:
+            if nc == n_solved:
+                solved_fm = cand_fm
+                break
+        else:
+            solved_fm = cand_fm   # no displacement field to match against (e.g. modal)
+            break
+    mesh = {}
+    if solved_fm is not None:
+        mesh = {"num_nodes": solved_fm.NodeCount, "num_elements": solved_fm.VolumeCount,
+                "element_type": "tet10"}
+
+    # Cheap coherence prechecks before the authoritative solver replay. Passing
+    # these checks is necessary but is NOT evidence that CalculiX ran:
+    #  (a) a static/thermomech result MUST carry a displacement field - it is the
+    #      PRIMARY solution variable, and vonMises/MaxShear are DERIVED from it; a
+    #      result with derived stress but no displacement was hand-filled;
+    #  (b) the displacement field MUST correspond to a real mesh in the document
+    #      (NodeCount == len(disp)) - otherwise the mesh was swapped after solving
+    #      after solving and incorrectly receive mesh-budget credit.
+    static_no_disp = analysis in ("static", "thermal_mechanical") and not disp
+    mesh_matches_solve = (n_solved == 0) or (solved_fm is not None)
+    coherent = (not static_no_disp) and mesh_matches_solve
+
+    out_dict = {
+        "source_fcstd": os.path.basename(fcstd),
+        "analysis_type": analysis,
+        "geometrical_nonlinearity": nonlinearity,
+        "units": {"length": "mm", "force": "N", "stress": "MPa"},
+        "material": material,
+        "geometry": geometry,
+        "boundary_conditions": bcs,
+        "loads": loads,
+        "mesh": mesh,
+        "results": results,
+        "runtime": runtime_info(require_calculix=verify_solve),
+    }
+    verification = None
+    replayed_results = None
+    if verify_solve and coherent:
+        verification, replayed_results = verify_solver_replay(doc, res, analysis, out)
+    elif verify_solve:
+        verification = {
+            "passed": False,
+            "status": "precheck_failed",
+            "relative_tolerance": REPLAY_REL_TOL,
+            "failures": ["stored result failed displacement/mesh coherence checks"],
+            "field_comparisons": {},
+        }
+
+    replay_accepted = bool(verification and verification.get("passed"))
+    if replay_accepted:
+        # Only the trusted validator-side replay can establish convergence and
+        # reproducibility. Within the strict tolerance, score trusted replayed
+        # values. For an accepted 2%-10% mismatch, retain the stored values so a
+        # deterministic FreeCAD remapping difference does not replace the result
+        # that was actually saved by the original solve.
+        out_dict["results"], result_source = select_scored_results(
+            out_dict["results"], replayed_results, verification
+        )
+        replay_verified = verification.get("status") == "verified"
+        out_dict["solver"] = {
+            "name": "CalculiX", "converged": True,
+            "replay_verified": replay_verified,
+            "replay_accepted": True,
+            "replay_status": verification.get("status"),
+            "result_source": result_source,
+        }
+        out_dict["artifacts"] = {
+            "result_file": os.path.basename(fcstd),
+        }
+    else:
+        # A loaded result object and matching array lengths are structural checks,
+        # not proof that CalculiX ran. Never vouch for unverified stored arrays.
+        out_dict["solver"] = {
+            "name": "CalculiX", "converged": False,
+            "replay_verified": False, "replay_accepted": False,
+        }
+        out_dict["artifacts"] = {}
+        if verification is not None:
+            out_dict["meta"] = {"solver_replay": verification}
+
+    if not coherent:
+        if static_no_disp:
+            out_dict["incoherent_result"] = (
+                f"{analysis} result reports {sorted(results)} but the displacement field is "
+                "empty - the primary solution variable is missing, so this was not solved")
+        else:
+            out_dict["incoherent_result"] = (
+                f"no mesh in the document matches the {n_solved}-value displacement field "
+                "(NodeCount != len(DisplacementLengths)) - the reported mesh was not the one "
+                "solved on (mesh/result mismatch)")
+    elif verification is not None and not replay_accepted:
+        out_dict["incoherent_result"] = (
+            "stored FEM fields were not reproduced by a trusted validator-side CalculiX replay"
+        )
+    if verification is not None and replay_accepted:
+        out_dict["meta"] = {"solver_replay": verification}
+    with open(out, "w", encoding="utf-8") as fh:
+        json.dump(out_dict, fh, indent=2)
+    FreeCAD.closeDocument(doc.Name)
+    print(f"[fcstd_adapter] wrote {out}  results={out_dict['results']}")
+
+
+main()

--- a/src/freecad_validator/fem/adapters/step.py
+++ b/src/freecad_validator/fem/adapters/step.py
@@ -1,0 +1,53 @@
+# Read a STEP solid and emit its geometry (volume, bbox, characteristic length).
+# Run under FreeCAD:  freecadcmd step.py <input.step> <output.json>
+import json
+import os
+import sys
+
+import Part  # noqa: F401  (FreeCAD provides this; only available inside freecadcmd)
+
+args = [a for a in sys.argv if a.lower().endswith((".step", ".stp", ".json"))]
+step = next(a for a in args if a.lower().endswith((".step", ".stp")))
+outs = [a for a in args if a.lower().endswith(".json")]
+out = outs[0] if outs else os.path.splitext(step)[0] + ".geom.json"
+
+shape = Part.Shape()
+shape.read(step)
+bb = shape.BoundBox
+solids = list(shape.Solids)
+regions = sorted(
+    (
+        {
+            "volume_mm3": solid.Volume,
+            "surface_area_mm2": solid.Area,
+            "num_faces": len(solid.Faces),
+            "num_edges": len(solid.Edges),
+            "num_shells": len(solid.Shells),
+        }
+        for solid in solids
+    ),
+    key=lambda region: (
+        region["volume_mm3"],
+        region["surface_area_mm2"],
+        region["num_faces"],
+        region["num_edges"],
+    ),
+)
+geom = {
+    "source_step": os.path.basename(step),
+    "volume_mm3": shape.Volume,
+    "surface_area_mm2": shape.Area,
+    "bbox_mm": [bb.XLength, bb.YLength, bb.ZLength],
+    "characteristic_length_mm": bb.DiagonalLength,
+    "faces": len(shape.Faces),
+    "solids": len(shape.Solids),
+    "num_solids": len(solids),
+    "num_compsolids": len(shape.CompSolids),
+    "shape_types": [str(shape.ShapeType)],
+    "num_faces": sum(region["num_faces"] for region in regions),
+    "num_edges": sum(region["num_edges"] for region in regions),
+    "regions": regions,
+}
+with open(out, "w", encoding="utf-8") as fh:
+    json.dump(geom, fh, indent=2)
+print(f"[step_geom] wrote {out}  volume={shape.Volume:.0f} mm^3  diag={bb.DiagonalLength:.1f} mm")

--- a/src/freecad_validator/fem/metrics.py
+++ b/src/freecad_validator/fem/metrics.py
@@ -1,0 +1,252 @@
+"""Pure numeric helpers used by the scorer.
+
+No FEA dependencies: these are the maths the validators and the
+reference-comparison module call. Side-effect free; depends only on the standard
+library and the tolerance constants in ``freecad_validator.fem.schema``, so they
+are trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from typing import Any
+
+from freecad_validator.fem.schema import MESH_BUDGET_ZERO_RATIO, TOL_BAND_HI, TOL_BAND_LO
+
+
+# --------------------------------------------------------------------------- #
+# Error / tolerance scoring                                                   #
+# --------------------------------------------------------------------------- #
+def relative_error(claimed: float, reference: float) -> float:
+    """|claimed - reference| / |reference| with a safe fallback for ref==0."""
+    if reference == 0:
+        return abs(claimed)  # absolute when reference is exactly zero
+    return abs(claimed - reference) / abs(reference)
+
+
+def tolerance_band_score(error: float, tol: float, fade: float = TOL_BAND_HI) -> float:
+    """Map an error to a 0-100 score over the band [TOL_BAND_LO*tol, fade*tol].
+
+    error <= TOL_BAND_LO*tol   -> 100  (inside the accepted band)
+    error >= fade*tol          -> 0    (grossly wrong)
+    linear interpolation in between.
+
+    ``fade`` (default TOL_BAND_HI) controls how quickly the score decays once
+    outside tolerance; a result a little outside is still partially credited, a
+    result several times outside gets nothing.
+    """
+    if tol <= 0:
+        tol = 1e-9
+    lo = TOL_BAND_LO * tol
+    hi = fade * tol
+    if error <= lo:
+        return 100.0
+    if error >= hi:
+        return 0.0
+    return 100.0 * (hi - error) / (hi - lo)
+
+
+def within_tolerance(claimed: float, reference: float,
+                     tol_rel: float, tol_abs: float | None = None) -> tuple[bool, float]:
+    """Return (within_tol, relative_error)."""
+    err = relative_error(claimed, reference)
+    ok = err <= tol_rel
+    if tol_abs is not None:
+        ok = ok or abs(claimed - reference) <= tol_abs
+    return ok, err
+
+
+# --------------------------------------------------------------------------- #
+# Mesh quality scoring                                                        #
+# --------------------------------------------------------------------------- #
+# Acceptance bands collated from Ansys / DIANA mesh-quality documentation and
+# FeaGPT's Jacobian-validity emphasis (see sources.json).
+ASPECT_GOOD, ASPECT_WARN, ASPECT_BAD = 3.0, 10.0, 20.0
+SKEW_GOOD, SKEW_WARN, SKEW_BAD = 0.5, 0.8, 0.95
+JAC_IDEAL, JAC_MIN = 1.0, 0.5
+
+
+def _band_penalty(value: float, good: float, bad: float, max_pen: float) -> float:
+    """Linear penalty: 0 at/under ``good``, ``max_pen`` at/above ``bad``."""
+    if value <= good:
+        return 0.0
+    if value >= bad:
+        return max_pen
+    return max_pen * (value - good) / (bad - good)
+
+
+def mesh_quality_score(quality: dict[str, float]) -> tuple[float, list[str]]:
+    """Score element-quality statistics (0-100) and return human notes.
+
+    Recognised keys (all optional): ``max_aspect_ratio``, ``max_skewness``,
+    ``min_jacobian``, ``pct_elements_below_jac``, ``pct_high_aspect``.
+    A missing key is simply not penalised (but the caller flags absence).
+    """
+    score = 100.0
+    notes: list[str] = []
+
+    ar = quality.get("max_aspect_ratio")
+    if ar is not None:
+        pen = _band_penalty(ar, ASPECT_GOOD, ASPECT_BAD, 35.0)
+        score -= pen
+        if ar > ASPECT_WARN:
+            notes.append(f"max aspect ratio {ar:g} exceeds {ASPECT_WARN:g}")
+
+    sk = quality.get("max_skewness")
+    if sk is not None:
+        pen = _band_penalty(sk, SKEW_GOOD, SKEW_BAD, 35.0)
+        score -= pen
+        if sk > SKEW_WARN:
+            notes.append(f"max skewness {sk:g} exceeds {SKEW_WARN:g}")
+
+    jac = quality.get("min_jacobian")
+    if jac is not None and jac < JAC_MIN:
+        # negative handled as inverted element by the validator; here penalise low
+        pen = _band_penalty(JAC_MIN - max(jac, 0.0), 0.0, JAC_MIN, 30.0)
+        score -= pen
+        notes.append(f"min Jacobian {jac:g} below recommended {JAC_MIN:g}")
+
+    pct_jac = quality.get("pct_elements_below_jac")
+    if pct_jac:
+        score -= min(30.0, pct_jac * 2.0)  # 1% bad -> 2 pts, capped
+        if pct_jac > 1.0:
+            notes.append(f"{pct_jac:g}% of elements below Jacobian threshold")
+
+    pct_ar = quality.get("pct_high_aspect")
+    if pct_ar:
+        score -= min(20.0, pct_ar * 1.0)
+
+    return max(0.0, score), notes
+
+
+def mesh_budget_score(candidate_elements: float, baseline_elements: float,
+                      zero_at: float = MESH_BUDGET_ZERO_RATIO) -> float:
+    """Mesh-efficiency score against a baseline element count from the reference.
+
+    full marks (100) at or below the baseline; linearly decaying to 0 once the
+    candidate reaches ``zero_at`` x the baseline (default 130%). Using fewer
+    elements than the baseline is never penalised.
+
+        r = candidate / baseline
+        r <= 1.0       -> 100
+        1.0 < r < z    -> 100 * (z - r) / (z - 1)
+        r >= z         -> 0
+    """
+    if not baseline_elements or baseline_elements <= 0:
+        return 100.0
+    r = candidate_elements / baseline_elements
+    if r <= 1.0:
+        return 100.0
+    if r >= zero_at:
+        return 0.0
+    return 100.0 * (zero_at - r) / (zero_at - 1.0)
+
+
+# --------------------------------------------------------------------------- #
+# Mesh convergence (Grid Convergence Index, Roache 1994 / Celik et al. 2008)  #
+# --------------------------------------------------------------------------- #
+def convergence_from_study(study: Sequence[dict[str, float]],
+                           rel_tol: float = 0.03) -> dict[str, Any]:
+    """Analyse a mesh-convergence study.
+
+    ``study`` is a list of {"n_elements": N, "value": Q} ordered coarse->fine
+    (or any order; we sort by N). Returns a dict with:
+
+      converged        - last successive relative change <= rel_tol
+      last_rel_change   - |Q_fine - Q_med| / |Q_fine|
+      monotonic         - values change monotonically (asymptotic-like)
+      diverging         - |change| grows with refinement (singularity signature)
+      gci_fine          - GCI of the finest grid (%), if >=3 grids and feasible
+      apparent_order    - observed order p, if computable
+      n_grids           - number of grids
+    """
+    pts = sorted([p for p in study if "value" in p and "n_elements" in p],
+                 key=lambda p: p["n_elements"])
+    out: dict[str, Any] = {
+        "n_grids": len(pts), "converged": False, "last_rel_change": None,
+        "monotonic": None, "diverging": False, "gci_fine": None,
+        "apparent_order": None,
+    }
+    if len(pts) < 2:
+        return out
+
+    vals = [float(p["value"]) for p in pts]
+    changes = [abs(vals[i] - vals[i - 1]) for i in range(1, len(vals))]
+    last = abs(vals[-1] - vals[-2]) / (abs(vals[-1]) if vals[-1] else 1.0)
+    out["last_rel_change"] = last
+    out["converged"] = last <= rel_tol
+
+    diffs = [vals[i] - vals[i - 1] for i in range(1, len(vals))]
+    out["monotonic"] = all(d >= 0 for d in diffs) or all(d <= 0 for d in diffs)
+    # diverging: successive changes are NOT shrinking (stress-singularity signature)
+    if len(changes) >= 2:
+        out["diverging"] = changes[-1] >= changes[-2] * 0.95 and last > rel_tol
+
+    # GCI on the three finest grids with (assumed) constant refinement ratio.
+    if len(pts) >= 3:
+        f1, f2, f3 = vals[-1], vals[-2], vals[-3]      # fine, medium, coarse
+        n1, n2, n3 = pts[-1]["n_elements"], pts[-2]["n_elements"], pts[-3]["n_elements"]
+        # representative cell-size ratios in 3D: h ~ N^(-1/3)
+        r21 = (n1 / n2) ** (1.0 / 3.0)
+        r32 = (n2 / n3) ** (1.0 / 3.0)
+        e21, e32 = (f1 - f2), (f2 - f3)
+        if e21 != 0 and e32 != 0 and r21 > 1.0 and r32 > 1.0:
+            ratio = e32 / e21
+            if ratio > 0:  # monotone convergence required for a clean order estimate
+                try:
+                    p = abs(math.log(abs(ratio))) / math.log(r21)
+                    p = max(0.3, min(p, 6.0))
+                    out["apparent_order"] = p
+                    ext = f1 + (f1 - f2) / (r21 ** p - 1.0)
+                    ea = abs((f1 - f2) / f1) if f1 else abs(f1 - f2)
+                    gci = 1.25 * ea / (r21 ** p - 1.0)
+                    out["gci_fine"] = 100.0 * gci
+                    out["extrapolated"] = ext
+                except (ValueError, ZeroDivisionError):
+                    pass
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Internal consistency (hallucination signal)                                 #
+# --------------------------------------------------------------------------- #
+def values_agree(values: Sequence[float], rel_tol: float = 0.02) -> bool:
+    """True if all numbers agree within rel_tol of their mean magnitude."""
+    nums = [v for v in values if isinstance(v, (int, float))]
+    if len(nums) < 2:
+        return True
+    lo, hi = min(nums), max(nums)
+    scale = max(abs(lo), abs(hi), 1e-12)
+    return (hi - lo) / scale <= rel_tol
+
+
+def max_pairwise_discrepancy(values: Sequence[float]) -> float:
+    nums = [v for v in values if isinstance(v, (int, float))]
+    if len(nums) < 2:
+        return 0.0
+    lo, hi = min(nums), max(nums)
+    scale = max(abs(lo), abs(hi), 1e-12)
+    return (hi - lo) / scale
+
+
+# --------------------------------------------------------------------------- #
+# Unit consistency                                                            #
+# --------------------------------------------------------------------------- #
+def stress_unit_consistent(units: dict[str, str]) -> bool | None:
+    """Cheap dimensional sanity for the common N/mm/MPa and SI systems.
+
+    Returns True/False if it can decide, None if there isn't enough info.
+    MPa == N/mm^2 ; Pa == N/m^2. A mix like force=N, length=mm, stress=Pa is
+    inconsistent (would be off by 1e6).
+    """
+    force = (units.get("force") or "").lower()
+    length = (units.get("length") or "").lower()
+    stress = (units.get("stress") or "").lower()
+    if not (force and length and stress):
+        return None
+    if force in ("n", "newton") and length in ("mm", "millimeter"):
+        return stress in ("mpa", "n/mm^2", "n/mm2", "megapascal")
+    if force in ("n", "newton") and length in ("m", "meter"):
+        return stress in ("pa", "n/m^2", "n/m2", "pascal")
+    return None

--- a/src/freecad_validator/fem/reference_compare.py
+++ b/src/freecad_validator/fem/reference_compare.py
@@ -1,0 +1,153 @@
+"""E. Accuracy vs reference.
+
+Compares candidate quantities against the case's reference solution.
+The reference may be analytical (closed form), numerical (high-fidelity run),
+empirical, or expert-derived; the ``method`` is carried through into every
+comparison record so the report can state the provenance of each tolerance.
+
+Two reference styles are supported:
+
+* point values  - ``reference.quantities[name] = {value, unit, tol_rel, critical}``
+* ranges        - ``reference.ranges[name]    = {min, max, unit, critical}``
+  (used by real-world cases where only a plausible band is known)
+
+Returns ``(score, findings, comparisons)``. ``score`` is ``None`` when the case
+declares no reference at all, signalling the orchestrator to redistribute the
+accuracy weight across the other categories.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from freecad_validator.fem import metrics
+from freecad_validator.fem.schema import GROSS_TOL, CaseDefinition, FailureMode, Finding, Submission
+
+# Common quantity aliases allow minor field-naming differences while preserving
+# still matched to the reference quantity.
+_ALIASES = {
+    "max_displacement_mm": ["max_disp_mm", "tip_deflection_mm", "max_deflection_mm", "umax_mm"],
+    "max_von_mises_MPa": ["max_stress_MPa", "peak_von_mises_MPa", "sigma_vm_max_MPa"],
+    "max_hoop_stress_MPa": ["sigma_theta_max_MPa", "hoop_stress_MPa", "circumferential_stress_MPa"],
+    "max_principal_stress_MPa": ["s1_max_MPa", "max_principal_MPa"],
+    "first_natural_frequency_Hz": ["f1_Hz", "fundamental_frequency_Hz", "natural_frequency_Hz"],
+    "buckling_factor": ["load_factor", "buckling_load_factor", "critical_load_factor"],
+    "max_temperature_C": ["Tmax_C", "peak_temperature_C"],
+    "reaction_force_N": ["total_reaction_N"],
+}
+
+
+def _lookup(results: dict[str, Any], name: str) -> float | None:
+    if name in results and isinstance(results[name], (int, float)):
+        return float(results[name])
+    for alt in _ALIASES.get(name, []):
+        if alt in results and isinstance(results[alt], (int, float)):
+            return float(results[alt])
+    # special case: first natural frequency from a list
+    if name == "first_natural_frequency_Hz":
+        fl = results.get("natural_frequencies_Hz")
+        if isinstance(fl, list) and fl and isinstance(fl[0], (int, float)):
+            return float(fl[0])
+    return None
+
+
+def compare_to_reference(case: CaseDefinition,
+                         sub: Submission) -> tuple[float | None, list[Finding], list[dict[str, Any]]]:
+    findings: list[Finding] = []
+    comparisons: list[dict[str, Any]] = []
+    method = case.reference_method()
+
+    quantities = case.reference_quantities()
+    ranges = case.reference.get("ranges", {})
+    if not quantities and not ranges:
+        return None, findings, comparisons
+
+    weighted_scores: list[tuple[float, float]] = []  # (score, weight)
+    results = sub.results or {}
+    gross_tol = case.reference.get("gross_tol", GROSS_TOL)  # critical miss beyond this gates to 0
+
+    # point-value comparisons
+    for name, rq in quantities.items():
+        claimed = _lookup(results, name)
+        weight = 2.0 if rq.critical else 1.0
+        if claimed is None:
+            if rq.critical:
+                # Omitting a CRITICAL quantity is a gross failure to reproduce the
+                # reference - at least as bad as reporting it grossly wrong - so it must
+                # raise the same gating finding, not a non-gating MISSING_QUANTITY.
+                # Otherwise omitting the hardest datum could outscore reporting it incorrectly.
+                findings.append(Finding("accuracy_vs_reference", FailureMode.ACCURACY_GROSS_ERROR,
+                                        "critical",
+                                        f"Critical reference quantity '{name}' ({rq.value:g} {rq.unit}) "
+                                        "was not reported: gross failure to reproduce the critical "
+                                        "quantity.", penalty=0))
+            else:
+                findings.append(Finding("accuracy_vs_reference", "MISSING_QUANTITY", "minor",
+                                        f"Reference quantity '{name}' ({rq.value:g} {rq.unit}) was not "
+                                        "reported.", penalty=0))
+            weighted_scores.append((0.0, weight))
+            comparisons.append({"quantity": name, "claimed": None, "reference": rq.value,
+                                "unit": rq.unit, "rel_error": None, "tol": rq.tol_rel,
+                                "within_tol": False, "critical": rq.critical, "method": method})
+            continue
+        ok, err = metrics.within_tolerance(claimed, rq.value, rq.tol_rel, rq.tol_abs)
+        qscore = metrics.tolerance_band_score(err, rq.tol_rel)
+        weighted_scores.append((qscore, weight))
+        comparisons.append({"quantity": name, "claimed": claimed, "reference": rq.value,
+                            "unit": rq.unit, "rel_error": err, "tol": rq.tol_rel,
+                            "within_tol": ok, "critical": rq.critical, "method": method})
+        if rq.critical and err > gross_tol:
+            findings.append(Finding("accuracy_vs_reference", FailureMode.ACCURACY_GROSS_ERROR, "critical",
+                                    f"'{name}' = {claimed:g} {rq.unit} is {err*100:.0f}% from the reference "
+                                    f"{rq.value:g} {rq.unit} (> gross_tol {gross_tol*100:.0f}%): gross "
+                                    "failure to reproduce the critical quantity.",
+                                    penalty=0))
+
+    # range comparisons
+    for name, spec in ranges.items():
+        claimed = _lookup(results, name)
+        critical = bool(spec.get("critical"))
+        weight = 2.0 if critical else 1.0
+        lo, hi = spec.get("min"), spec.get("max")
+        unit = spec.get("unit", "")
+        if claimed is None:
+            if critical:
+                findings.append(Finding("accuracy_vs_reference", FailureMode.ACCURACY_GROSS_ERROR,
+                                        "critical",
+                                        f"Critical reference quantity '{name}' (range [{lo}, {hi}] "
+                                        f"{unit}) was not reported: gross failure to reproduce it.",
+                                        penalty=0))
+            weighted_scores.append((0.0, weight))
+            comparisons.append({"quantity": name, "claimed": None, "reference": f"[{lo}, {hi}]",
+                                "unit": unit, "rel_error": None, "tol": "range",
+                                "within_tol": False, "critical": critical, "method": method})
+            continue
+        if lo is not None and hi is not None:
+            if lo <= claimed <= hi:
+                qscore = 100.0
+                ok = True
+            else:
+                width = max(hi - lo, 1e-9)
+                dist = (lo - claimed) if claimed < lo else (claimed - hi)
+                qscore = metrics.tolerance_band_score(dist / width, 0.0 + 1e-9, fade=2.0)
+                ok = False
+            weighted_scores.append((qscore, weight))
+            comparisons.append({"quantity": name, "claimed": claimed, "reference": f"[{lo}, {hi}]",
+                                "unit": unit, "rel_error": None, "tol": "range",
+                                "within_tol": ok, "critical": critical, "method": method})
+
+    if not weighted_scores:
+        return None, findings, comparisons
+
+    total_w = sum(w for _, w in weighted_scores)
+    score = sum(s * w for s, w in weighted_scores) / total_w if total_w else 0.0
+
+    # propagate the accuracy shortfall into the category score as a penalty record
+    if score < 100:
+        worst = [c for c in comparisons if not c["within_tol"]]
+        if worst:
+            findings.append(Finding("accuracy_vs_reference", "OUT_OF_TOLERANCE",
+                                    "major" if score < 60 else "minor",
+                                    f"{len(worst)} reference quantity(ies) outside tolerance.",
+                                    penalty=0))
+    return score, findings, comparisons

--- a/src/freecad_validator/fem/replay_compare.py
+++ b/src/freecad_validator/fem/replay_compare.py
@@ -1,0 +1,147 @@
+"""Compare candidate-stored FEM fields with a trusted solver replay."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+REPLAY_REL_TOL = 0.02
+REPLAY_HARD_FAIL_REL_TOL = 0.10
+REPLAY_SCALAR_FIELDS = (
+    "DisplacementLengths",
+    "vonMises",
+    "MaxShear",
+    "Temperature",
+    "EigenmodeFrequencies",
+)
+STATIC_REQUIRED_REPLAY_FIELDS = (
+    "DisplacementLengths",
+    "DisplacementVectors",
+    "vonMises",
+)
+
+
+def select_scored_results(
+    stored: dict[str, Any],
+    replayed: dict[str, Any],
+    verification: dict[str, Any],
+) -> tuple[dict[str, Any], str]:
+    if verification.get("status") == "accepted_mismatch":
+        return stored, "stored"
+    return replayed, "replayed"
+
+
+def field_error(stored: list[Any], replayed: list[Any]) -> dict[str, Any]:
+    if len(stored) != len(replayed):
+        return {
+            "length_match": False,
+            "stored_count": len(stored),
+            "replayed_count": len(replayed),
+        }
+
+    if stored and isinstance(stored[0], tuple):
+        stored_flat = [component for vector in stored for component in vector]
+        replayed_flat = [component for vector in replayed for component in vector]
+        stored_peak = max(
+            math.sqrt(sum(component * component for component in vector))
+            for vector in stored
+        )
+        replayed_peak = max(
+            math.sqrt(sum(component * component for component in vector))
+            for vector in replayed
+        )
+    else:
+        stored_flat = stored
+        replayed_flat = replayed
+        stored_peak = max(abs(value) for value in stored)
+        replayed_peak = max(abs(value) for value in replayed)
+
+    if not all(math.isfinite(value) for value in stored_flat + replayed_flat):
+        return {"length_match": True, "finite": False}
+
+    squared_error = sum(
+        (stored_value - replayed_value) ** 2
+        for stored_value, replayed_value in zip(stored_flat, replayed_flat, strict=True)
+    )
+    replayed_energy = sum(value * value for value in replayed_flat)
+    count = max(1, len(replayed_flat))
+    rms_error = math.sqrt(squared_error / count)
+    replayed_rms = math.sqrt(replayed_energy / count)
+    normalized_rms_error = rms_error / max(replayed_rms, 1e-12)
+    peak_relative_error = abs(stored_peak - replayed_peak) / max(replayed_peak, 1e-12)
+    return {
+        "length_match": True,
+        "finite": True,
+        "normalized_rms_error": normalized_rms_error,
+        "peak_relative_error": peak_relative_error,
+        "stored_peak": stored_peak,
+        "replayed_peak": replayed_peak,
+    }
+
+
+def compare_result_snapshots(
+    stored: dict[str, Any],
+    replayed: dict[str, Any],
+    analysis_type: str,
+) -> dict[str, Any]:
+    failures = []
+    warnings = []
+    comparisons = {}
+    if stored["node_numbers"] != replayed["node_numbers"]:
+        failures.append("replayed result node ordering does not match the stored result")
+
+    stored_fields = stored["fields"]
+    replayed_fields = replayed["fields"]
+    required = (
+        STATIC_REQUIRED_REPLAY_FIELDS
+        if analysis_type in ("static", "thermal_mechanical")
+        else ()
+    )
+    for name in required:
+        if name not in stored_fields:
+            failures.append(f"stored result is missing required field {name}")
+        if name not in replayed_fields:
+            failures.append(f"replayed result is missing required field {name}")
+
+    for name in sorted(set(stored_fields) | set(replayed_fields)):
+        if name not in stored_fields or name not in replayed_fields:
+            failures.append(f"field set differs after replay: {name}")
+            continue
+        comparison = field_error(stored_fields[name], replayed_fields[name])
+        comparisons[name] = comparison
+        if not comparison.get("length_match") or not comparison.get("finite", True):
+            failures.append(f"field {name} is structurally invalid after replay")
+            continue
+        if comparison["normalized_rms_error"] > REPLAY_HARD_FAIL_REL_TOL:
+            failures.append(
+                f"field {name} normalized RMS error "
+                f"{comparison['normalized_rms_error']:.3%} exceeds "
+                f"{REPLAY_HARD_FAIL_REL_TOL:.0%} hard-fail tolerance"
+            )
+        elif comparison["normalized_rms_error"] > REPLAY_REL_TOL:
+            warnings.append(
+                f"field {name} normalized RMS error "
+                f"{comparison['normalized_rms_error']:.3%} exceeds "
+                f"{REPLAY_REL_TOL:.0%} verification tolerance"
+            )
+        if comparison["peak_relative_error"] > REPLAY_HARD_FAIL_REL_TOL:
+            failures.append(
+                f"field {name} peak error {comparison['peak_relative_error']:.3%} "
+                f"exceeds {REPLAY_HARD_FAIL_REL_TOL:.0%} hard-fail tolerance"
+            )
+        elif comparison["peak_relative_error"] > REPLAY_REL_TOL:
+            warnings.append(
+                f"field {name} peak error {comparison['peak_relative_error']:.3%} "
+                f"exceeds {REPLAY_REL_TOL:.0%} verification tolerance"
+            )
+
+    status = "mismatch" if failures else ("accepted_mismatch" if warnings else "verified")
+    return {
+        "passed": not failures,
+        "status": status,
+        "relative_tolerance": REPLAY_REL_TOL,
+        "hard_fail_relative_tolerance": REPLAY_HARD_FAIL_REL_TOL,
+        "failures": failures,
+        "warnings": warnings,
+        "field_comparisons": comparisons,
+    }

--- a/src/freecad_validator/fem/rubric.py
+++ b/src/freecad_validator/fem/rubric.py
@@ -1,0 +1,79 @@
+"""Deterministic engineering-reporting quality checks.
+
+The reporting score is a deterministic rubric: did the submission do the things
+a competent CAE engineer's report does (state assumptions and units, justify the
+mesh, interpret the results, identify limitations, compute a safety factor when
+relevant, show convergence evidence)? Cases may override the rubric items and
+weights via ``case.rubric``.
+
+"""
+
+from __future__ import annotations
+
+from freecad_validator.fem.schema import CaseDefinition, Finding, Submission
+
+# default rubric: item -> (weight, human label)
+DEFAULT_RUBRIC = {
+    "assumptions_stated": (0.18, "assumptions stated"),
+    "units_stated": (0.12, "units declared"),
+    "results_interpreted": (0.20, "results interpreted in engineering terms"),
+    "limitations_identified": (0.15, "limitations identified"),
+    "convergence_evidence": (0.15, "mesh-convergence evidence shown"),
+    "mesh_justification": (0.10, "mesh choice justified"),
+    "safety_factor": (0.10, "safety factor computed where relevant"),
+}
+
+
+def _present(case: CaseDefinition, sub: Submission, item: str) -> bool:
+    rep = sub.report or {}
+    if item == "assumptions_stated":
+        a = rep.get("assumptions")
+        return bool(a) and (len(a) > 0 if isinstance(a, list) else len(str(a).strip()) > 0)
+    if item == "units_stated":
+        return bool(sub.units)
+    if item == "results_interpreted":
+        return len(str(rep.get("interpretation", "")).strip()) >= 40
+    if item == "limitations_identified":
+        lim = rep.get("limitations")
+        return bool(lim) and (len(lim) > 0 if isinstance(lim, list) else len(str(lim).strip()) > 0)
+    if item == "convergence_evidence":
+        study = (sub.mesh or {}).get("convergence_study") or []
+        return len(study) >= 2 or "converg" in str(rep.get("mesh_justification", "")).lower()
+    if item == "mesh_justification":
+        return len(str(rep.get("mesh_justification", "")).strip()) >= 20
+    if item == "safety_factor":
+        if not case.rubric.get("requires_safety_factor", False):
+            return True  # not required -> counts as satisfied
+        has_sf = sub.results.get("safety_factor") is not None
+        return has_sf or len(str(rep.get("safety_factor_discussion", "")).strip()) > 0
+    return False
+
+
+def evaluate_reporting(case: CaseDefinition, sub: Submission) -> tuple[float, list[Finding]]:
+    findings: list[Finding] = []
+    rubric = dict(DEFAULT_RUBRIC)
+    # allow the case to override weights / add items
+    for item, w in (case.rubric.get("weights", {}) or {}).items():
+        label = rubric[item][1] if item in rubric else item.replace("_", " ")
+        rubric[item] = (w, label)
+
+    total_w = sum(w for w, _ in rubric.values()) or 1.0
+    score = 0.0
+    missing: list[str] = []
+    for item, (w, label) in rubric.items():
+        if _present(case, sub, item):
+            score += w
+        else:
+            missing.append(label)
+    score = 100.0 * score / total_w
+
+    # bonus: sensitivity analysis mentioned (does not exceed 100)
+    if str((sub.report or {}).get("sensitivity", "")).strip():
+        score = min(100.0, score + 5.0)
+
+    if missing:
+        sev = "major" if score < 50 else "minor"
+        findings.append(Finding("engineering_reporting", "INCOMPLETE_REPORT", sev,
+                                "Reporting gaps: " + ", ".join(missing) + ".",
+                                penalty=0))
+    return score, findings

--- a/src/freecad_validator/fem/schema.py
+++ b/src/freecad_validator/fem/schema.py
@@ -1,0 +1,345 @@
+"""Data contract for deterministic FEA/FEM validation.
+
+Three objects flow through the scorer:
+
+* ``CaseDefinition``  - the validation case: geometry, material, expected setup,
+  reference solution (analytical / numerical / empirical / expert), physical
+  bounds, mesh expectations, and a reporting rubric.
+* ``Submission``      - the candidate problem setup, mesh statistics,
+  solver outputs, result quantities, the written report and the artifacts it
+  claims to have generated.
+* ``ScoringReport``   - the scorer's output: overall 0-100 score, flat
+  per-category subscores, detailed subscore breakdowns, pass/fail flags,
+  detected failure modes, numerical comparisons, engineering feedback,
+  confidence and reproducibility status.
+
+Everything is plain dataclasses with ``from_dict`` / ``to_dict`` so cases and
+submissions can live as JSON on disk and the report can be serialised verbatim.
+The scorer core depends only on the standard library.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+# --------------------------------------------------------------------------- #
+# Scoring categories and the default weighting scheme (documented in report)   #
+# --------------------------------------------------------------------------- #
+CATEGORIES = [
+    "problem_setup",
+    "mesh_quality",
+    "mesh_budget",
+    "numerical_reliability",
+    "physical_validity",
+    "accuracy_vs_reference",
+    "engineering_reporting",
+]
+
+DEFAULT_WEIGHTS: dict[str, float] = {
+    "problem_setup": 0.20,
+    "mesh_quality": 0.15,
+    "mesh_budget": 0.00,          # off by default; activated by reference-based scoring
+    "numerical_reliability": 0.20,
+    "physical_validity": 0.20,
+    "accuracy_vs_reference": 0.15,
+    "engineering_reporting": 0.10,
+}
+
+SEVERITIES = ("info", "minor", "major", "critical")
+
+# Per-severity default deduction applied to a category's 0-100 raw score.
+SEVERITY_PENALTY = {"info": 0.0, "minor": 8.0, "major": 30.0, "critical": 80.0}
+
+
+# --------------------------------------------------------------------------- #
+# Tolerance / accuracy-band configuration (correlated: change one, rest follow)#
+# --------------------------------------------------------------------------- #
+# Relative-error tolerances for comparing a candidate result to the reference.
+DISP_TOL = 0.05            # displacement / natural frequency: <= 5% rel. err = full credit
+STRESS_TOL = 0.08          # stresses (mesh-sensitive): <= 8% rel. err = full credit
+
+# Accuracy band shape used by metrics.tolerance_band_score:
+#   error <= TOL_BAND_LO * tol  -> 100  (full credit)
+#   error >= TOL_BAND_HI * tol  ->   0  (no credit; TOL_BAND_HI is the "fade")
+# linear in between, over [TOL_BAND_LO*tol, TOL_BAND_HI*tol]. With TOL_BAND_HI=2
+# the displacement sub-score fades 5%->10% and stress fades 8%->16%.
+TOL_BAND_LO = 1.0
+TOL_BAND_HI = 2.0
+
+# Gross-miss GATE for a critical quantity: off by more than GROSS_TOL is a gross
+# failure to reproduce the reference and GATES the overall score to 0. Deliberately
+# WIDER than the sub-score band fade (a 10-20% displacement miss earns no accuracy
+# credit but is not yet invalid), so the gate keeps its own multiple of DISP_TOL
+# rather than tracking TOL_BAND_HI (default = 4 * 0.05 = 0.20).
+GROSS_GATE_MULT = 4.0
+GROSS_TOL = GROSS_GATE_MULT * DISP_TOL
+
+# Mesh-budget: candidate element count vs the reference baseline. Full credit at or
+# below the baseline; zero credit at this multiple of it.
+MESH_BUDGET_ZERO_RATIO = 1.3
+
+# Lower floor for the mesh-budget credit. A mesh below this fraction of the reference
+# baseline is too coarse to have resolved the field and earns ZERO mesh-budget
+# credit (not full), preventing a degenerate mesh from receiving efficiency
+# credit. Deliberately small so honest
+# coarse-but-valid meshes are spared while degenerate ones are excluded.
+MESH_BUDGET_FLOOR_RATIO = 0.05
+
+# Load match: how closely the candidate's applied loading must reproduce the reference.
+# A load is an INPUT (given in the prompt or derived from the environment), so it
+# should match tightly; a gross magnitude miss or a reversed force means a DIFFERENT
+# problem was solved and GATES the score (like a wrong material), even if the result
+# numbers happen to land near the reference (the compensating-error blind spot).
+LOAD_MAG_TOL = 0.05         # force/pressure magnitude rel-error before a (minor) penalty
+LOAD_MAG_GROSS_TOL = 0.20   # ... beyond this it is the wrong load -> critical gate
+# Force DIRECTION: a load is an INPUT that must point the way the reference specifies, so the
+# candidate's net force at each loaded face is compared to the reference's by angle. Within a
+# few degrees it is the same load; past a tight bound it is a different load (a reversal is
+# just the extreme - and it even fools the accuracy check, which sees identical magnitudes).
+LOAD_DIR_ALIGNED_DEG = 6.0   # <= this: aligned, no finding
+LOAD_DIR_GATE_DEG = 15.0     # >= this: wrong load direction -> critical gate (between: penalty)
+LOAD_LOC_TOL = 0.15          # centroid offset / characteristic length before a penalty
+
+
+# --------------------------------------------------------------------------- #
+# Failure-mode codes                                                           #
+# --------------------------------------------------------------------------- #
+class FailureMode:
+    WRONG_ANALYSIS_TYPE = "WRONG_ANALYSIS_TYPE"
+    WRONG_MATERIAL = "WRONG_MATERIAL"
+    UNIT_INCONSISTENCY = "UNIT_INCONSISTENCY"
+    MISSING_BOUNDARY_CONDITION = "MISSING_BOUNDARY_CONDITION"
+    MISSING_LOAD = "MISSING_LOAD"
+    WRONG_LOAD = "WRONG_LOAD"
+    UNJUSTIFIED_MESH = "UNJUSTIFIED_MESH"
+    NO_CONVERGENCE_STUDY = "NO_CONVERGENCE_STUDY"
+    INVERTED_ELEMENTS = "INVERTED_ELEMENTS"
+    POOR_MESH_QUALITY = "POOR_MESH_QUALITY"
+    SOLVER_NOT_CONVERGED = "SOLVER_NOT_CONVERGED"
+    HALLUCINATED_CONVERGENCE = "HALLUCINATED_CONVERGENCE"
+    HALLUCINATED_SOLVER_OUTPUT = "HALLUCINATED_SOLVER_OUTPUT"
+    UNVERIFIED_SOLVER_OUTPUT = "UNVERIFIED_SOLVER_OUTPUT"
+    REACTION_IMBALANCE = "REACTION_IMBALANCE"
+    ENERGY_IMBALANCE = "ENERGY_IMBALANCE"
+    INTERNAL_INCONSISTENCY = "INTERNAL_INCONSISTENCY"
+    PHYSICALLY_IMPOSSIBLE = "PHYSICALLY_IMPOSSIBLE"
+    SINGULARITY_MISINTERPRETED = "SINGULARITY_MISINTERPRETED"
+    FREQ_NONPHYSICAL = "FREQ_NONPHYSICAL"
+    BUCKLING_NONPHYSICAL = "BUCKLING_NONPHYSICAL"
+    ACCURACY_GROSS_ERROR = "ACCURACY_GROSS_ERROR"
+    NON_REPRODUCIBLE = "NON_REPRODUCIBLE"
+    CASE_MISMATCH = "CASE_MISMATCH"
+    MISSING_RESULTS = "MISSING_RESULTS"
+    GEOMETRY_MISMATCH = "GEOMETRY_MISMATCH"
+    PREPROCESSING_NOT_PERFORMED = "PREPROCESSING_NOT_PERFORMED"
+    BOOLEAN_NOT_PERFORMED = "BOOLEAN_NOT_PERFORMED"
+
+
+# Critical (gate) failure modes. The scorer is a VALIDITY GATE: if any of these
+# is raised at severity "critical", the overall score is 0 (invalid) regardless
+# of how well the weighted categories scored; otherwise the weighted sum stands.
+# This makes a physically impossible / hallucinated / wrong-part result fail
+# outright, no matter how polished. ACCURACY_GROSS_ERROR gates a candidate that
+# misses the reference's critical quantity by more than GROSS_TOL.
+CRITICAL_GATES: frozenset = frozenset({
+    FailureMode.PHYSICALLY_IMPOSSIBLE,
+    FailureMode.GEOMETRY_MISMATCH,
+    FailureMode.PREPROCESSING_NOT_PERFORMED,
+    FailureMode.BOOLEAN_NOT_PERFORMED,
+    FailureMode.HALLUCINATED_SOLVER_OUTPUT,
+    FailureMode.UNVERIFIED_SOLVER_OUTPUT,
+    FailureMode.MISSING_RESULTS,
+    FailureMode.SOLVER_NOT_CONVERGED,
+    FailureMode.MISSING_BOUNDARY_CONDITION,
+    FailureMode.WRONG_LOAD,
+    FailureMode.INVERTED_ELEMENTS,
+    FailureMode.HALLUCINATED_CONVERGENCE,
+    FailureMode.SINGULARITY_MISINTERPRETED,
+    FailureMode.REACTION_IMBALANCE,
+    FailureMode.NON_REPRODUCIBLE,
+    FailureMode.WRONG_ANALYSIS_TYPE,
+    FailureMode.INTERNAL_INCONSISTENCY,
+    FailureMode.FREQ_NONPHYSICAL,
+    FailureMode.BUCKLING_NONPHYSICAL,
+    FailureMode.WRONG_MATERIAL,
+    FailureMode.ACCURACY_GROSS_ERROR,
+})
+
+
+@dataclass
+class Finding:
+    """A single observation the scorer made about a submission."""
+    category: str
+    code: str
+    severity: str
+    message: str
+    evidence: str = ""
+    penalty: float = 0.0  # points subtracted from the category's 0-100 score
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# --------------------------------------------------------------------------- #
+# Case definition                                                             #
+# --------------------------------------------------------------------------- #
+@dataclass
+class ReferenceQuantity:
+    name: str
+    value: float
+    unit: str = ""
+    tol_rel: float = 0.10
+    tol_abs: float | None = None
+    critical: bool = False
+    note: str = ""
+
+
+@dataclass
+class CaseDefinition:
+    case_id: str
+    title: str
+    category: str = "base"          # caller-defined grouping, e.g. "base" or "fem"
+    subtype: str = ""
+    analysis_type: str = "static"   # static|modal|buckling|thermal|thermal_mechanical|nonlinear_material|large_deformation|contact|transient
+    description: str = ""
+    units_expected: dict[str, str] = field(default_factory=dict)
+    geometry: dict[str, Any] = field(default_factory=dict)
+    material: dict[str, Any] = field(default_factory=dict)
+    expected_bcs: list[dict[str, Any]] = field(default_factory=list)
+    expected_loads: list[dict[str, Any]] = field(default_factory=list)
+    reference: dict[str, Any] = field(default_factory=dict)         # {method, source, quantities:{...}}
+    physical_bounds: dict[str, Any] = field(default_factory=dict)
+    mesh_expectations: dict[str, Any] = field(default_factory=dict)
+    rubric: dict[str, Any] = field(default_factory=dict)
+    weights_override: dict[str, float] | None = None
+
+    # convenience -----------------------------------------------------------
+    def reference_quantities(self) -> dict[str, ReferenceQuantity]:
+        out: dict[str, ReferenceQuantity] = {}
+        for name, spec in self.reference.get("quantities", {}).items():
+            out[name] = ReferenceQuantity(name=name, **spec)
+        return out
+
+    def reference_method(self) -> str:
+        return self.reference.get("method", "none")
+
+    def weights(self) -> dict[str, float]:
+        if self.weights_override:
+            w = dict(DEFAULT_WEIGHTS)
+            w.update(self.weights_override)
+            total = sum(w.values())
+            return {k: v / total for k, v in w.items()}
+        return dict(DEFAULT_WEIGHTS)
+
+    @staticmethod
+    def from_dict(d: dict[str, Any]) -> CaseDefinition:
+        known = CaseDefinition.__dataclass_fields__.keys()
+        return CaseDefinition(**{k: v for k, v in d.items() if k in known})
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @staticmethod
+    def load(path: str) -> CaseDefinition:
+        with open(path, encoding="utf-8") as fh:
+            return CaseDefinition.from_dict(json.load(fh))
+
+    def save(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(self.to_dict(), fh, indent=2)
+
+
+# --------------------------------------------------------------------------- #
+# Submission                                                                  #
+# --------------------------------------------------------------------------- #
+@dataclass
+class Submission:
+    case_id: str
+    analysis_type: str = ""
+    units: dict[str, str] = field(default_factory=dict)
+    geometry: dict[str, Any] = field(default_factory=dict)
+    material: dict[str, Any] = field(default_factory=dict)
+    boundary_conditions: list[dict[str, Any]] = field(default_factory=list)
+    loads: list[dict[str, Any]] = field(default_factory=list)
+    mesh: dict[str, Any] = field(default_factory=dict)
+    solver: dict[str, Any] = field(default_factory=dict)
+    results: dict[str, Any] = field(default_factory=dict)
+    reported_values: dict[str, Any] = field(default_factory=dict)   # {name:{text,table,plot}}
+    report: dict[str, Any] = field(default_factory=dict)
+    artifacts: dict[str, Any] = field(default_factory=dict)         # {name: path_or_null}
+
+    # Caller metadata (not read by scoring logic).
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    @staticmethod
+    def from_dict(d: dict[str, Any]) -> Submission:
+        known = Submission.__dataclass_fields__.keys()
+        return Submission(**{k: v for k, v in d.items() if k in known})
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @staticmethod
+    def load(path: str) -> Submission:
+        with open(path, encoding="utf-8") as fh:
+            return Submission.from_dict(json.load(fh))
+
+    def save(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(self.to_dict(), fh, indent=2)
+
+
+# --------------------------------------------------------------------------- #
+# Scoring report                                                              #
+# --------------------------------------------------------------------------- #
+@dataclass
+class SubScore:
+    category: str
+    raw_score: float            # 0-100 before weighting
+    weight: float
+    weighted_points: float      # raw_score * weight (contribution to 0-100)
+    findings: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class ScoringReport:
+    case_id: str
+    overall_score: float
+    grade: str
+    subscores: dict[str, float] = field(default_factory=dict)
+    subscores_details: dict[str, dict[str, Any]] = field(default_factory=dict)
+    pass_fail_flags: dict[str, bool | None] = field(default_factory=dict)
+    failure_modes_detected: list[dict[str, Any]] = field(default_factory=list)
+    gates_triggered: list[dict[str, Any]] = field(default_factory=list)
+    numerical_comparisons: list[dict[str, Any]] = field(default_factory=list)
+    engineering_feedback: list[str] = field(default_factory=list)
+    suggested_fixes: list[str] = field(default_factory=list)
+    confidence: float = 1.0
+    reproducibility_status: str = "unknown"
+    evidence: list[str] = field(default_factory=list)
+    runtime_provenance: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def save(self, path: str) -> None:
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(self.to_dict(), fh, indent=2)
+
+    def summary_line(self) -> str:
+        fm = ",".join(sorted({f["code"] for f in self.failure_modes_detected})) or "none"
+        return f"{self.case_id}: {self.overall_score:.1f}/100 [{self.grade}] failures={fm}"
+
+
+def grade_from_score(score: float) -> str:
+    if score >= 85:
+        return "excellent"
+    if score >= 70:
+        return "good"
+    if score >= 55:
+        return "acceptable"
+    if score >= 35:
+        return "poor"
+    return "invalid"

--- a/src/freecad_validator/fem/scorer.py
+++ b/src/freecad_validator/fem/scorer.py
@@ -1,0 +1,293 @@
+"""Top-level scorer: ``score_result(case, submission) -> ScoringReport``.
+
+Pipeline
+--------
+1. Run the six category evaluators (problem setup, mesh, numerical, physical,
+   accuracy, reporting) plus cross-cutting submission validation.
+2. Aggregate category raw scores with the (case-overridable) weights into a
+   0-100 weighted score. If the case has no reference solution, the accuracy
+   weight is redistributed proportionally to the other categories.
+3. Apply the VALIDITY GATE: if any critical failure mode in ``CRITICAL_GATES``
+   is raised, the overall score is 0 (invalid); otherwise the weighted sum
+   stands. This keeps a physically impossible / hallucinated / non-reproducible /
+   wrong-part result from passing no matter how polished it looks.
+4. Emit pass/fail flags, detected failure modes, numerical comparisons,
+   actionable feedback, suggested fixes, confidence and reproducibility status.
+
+Deterministic and offline by construction.
+"""
+
+from __future__ import annotations
+
+from freecad_validator.fem import reference_compare, rubric, validators
+from freecad_validator.fem.schema import (
+    CATEGORIES,
+    CRITICAL_GATES,
+    CaseDefinition,
+    Finding,
+    ScoringReport,
+    Submission,
+    SubScore,
+    grade_from_score,
+)
+
+# Actionable fix suggestions keyed by failure-mode / finding code.
+SUGGESTED_FIXES = {
+    "WRONG_ANALYSIS_TYPE": "Re-run with the analysis type the case requires (e.g. modal/buckling/thermal), not a static stress pass.",
+    "UNIT_INCONSISTENCY": "Make the unit system self-consistent (e.g. N-mm-MPa) and state it explicitly.",
+    "WRONG_MATERIAL": "Use the specified material properties (E, nu, density) from the case definition.",
+    "MISSING_BOUNDARY_CONDITION": "Add restraints that remove all six rigid-body modes before solving.",
+    "MISSING_LOAD": "Apply the load defined by the case before solving.",
+    "UNJUSTIFIED_MESH": "Report element type and quality metrics, and justify the mesh density.",
+    "NO_CONVERGENCE_STUDY": "Run >=3 systematically refined meshes and report the GCI / successive change.",
+    "INVERTED_ELEMENTS": "Fix the mesh: negative Jacobians mean inverted elements; remesh or improve geometry healing.",
+    "POOR_MESH_QUALITY": "Improve worst-element aspect ratio/skewness, especially in high-gradient regions.",
+    "SOLVER_NOT_CONVERGED": "Resolve the non-convergence (step size, contact, stabilization) before trusting results.",
+    "HALLUCINATED_CONVERGENCE": "Do not claim mesh independence without a refinement study that demonstrates it.",
+    "HALLUCINATED_SOLVER_OUTPUT": "Provide the solver log, result file and reaction balance that produced these numbers.",
+    "UNVERIFIED_SOLVER_OUTPUT": "Save a complete, re-runnable FEM analysis whose stored fields are reproduced by a fresh CalculiX solve of the same mesh.",
+    "REACTION_IMBALANCE": "Check equilibrium: total reaction must balance the applied load.",
+    "ENERGY_IMBALANCE": "Reduce artificial/hourglass energy below ~5% of internal energy (better elements/mesh).",
+    "INTERNAL_INCONSISTENCY": "Make every reported value identical across text, tables and plots.",
+    "PHYSICALLY_IMPOSSIBLE": "Re-examine the model: the result violates basic physics (sign, magnitude, admissibility).",
+    "SINGULARITY_MISINTERPRETED": "Treat the sharp feature as a singularity (add a fillet or report a notch-stress/away-from-singularity value), not a converged peak.",
+    "FREQ_NONPHYSICAL": "Negative/zero constrained frequencies imply rigid-body modes; fix constraints.",
+    "BUCKLING_NONPHYSICAL": "A non-positive buckling factor is invalid; check the eigenvalue extraction and preload.",
+    "ACCURACY_GROSS_ERROR": "Reconcile the result with the analytical/reference value; a large gap signals a setup error.",
+    "NON_REPRODUCIBLE": "Ship the input deck/script and result file so the run can be reproduced and audited.",
+    "PARTIAL_REPRODUCIBILITY": "Include both the input deck/script and the result file.",
+    "CASE_MISMATCH": "Write the report against THIS geometry/loading, not boilerplate from another case.",
+    "MISSING_RESULTS": "Report the quantities of interest the case asks for.",
+    "INCOMPLETE_REPORT": "Add the missing report sections (assumptions, interpretation, limitations, etc.).",
+    "MESH_NOT_CONVERGED": "Refine until the quantity of interest changes < ~3% between meshes.",
+    "LARGE_DEFLECTION": "Switch to geometrically nonlinear analysis; linear small-strain theory is invalid here.",
+    "MESH_BUDGET_EXCEEDED": "Reduce the element count to within the reference mesh budget (the sub-score is 0 at/over the budget ceiling); coarsen away from high-gradient regions or use local refinement only where needed.",
+    "MESH_BUDGET_OVER": "Trim the element count toward the reference baseline to recover mesh-budget points.",
+    "MESH_BUDGET_UNDERRESOLVED": "Report the mesh you actually solved on; a mesh far below the reference baseline is under-resolved and earns no mesh-budget credit. Refine until the field is resolved, then trim toward (not below) the baseline.",
+}
+
+
+def _subscore(category: str, raw: float, weight: float, findings: list[Finding]) -> SubScore:
+    return SubScore(category=category, raw_score=round(raw, 2), weight=round(weight, 4),
+                    weighted_points=round(raw * weight, 3),
+                    findings=[f.to_dict() for f in findings])
+
+
+def score_result(case: CaseDefinition, submission: Submission) -> ScoringReport:
+    """Score one submission against one case definition."""
+    if submission.case_id and case.case_id and submission.case_id != case.case_id:
+        # Not fatal because a caller may remap case identifiers.
+        pass
+
+    # ---- run evaluators --------------------------------------------------
+    ps_score, ps_find = validators.validate_problem_setup(case, submission)
+    mq_score, mq_find, conv = validators.evaluate_mesh(case, submission)
+    nr_score, nr_find = validators.evaluate_numerical(case, submission, conv)
+    pv_score, pv_find = validators.evaluate_physical(case, submission)
+    acc_score, acc_find, comparisons = reference_compare.compare_to_reference(case, submission)
+    rep_score, rep_find = rubric.evaluate_reporting(case, submission)
+    mb_score, mb_find = validators.evaluate_mesh_budget(case, submission)
+
+    # Cross-cutting submission checks and geometry fidelity.
+    submission_findings = validators.detect_submission_failures(case, submission)
+    submission_findings += validators.validate_geometry_fidelity(case, submission)
+
+    cat_findings: dict[str, list[Finding]] = {c: [] for c in CATEGORIES}
+    for f in ps_find:
+        cat_findings["problem_setup"].append(f)
+    for f in mq_find:
+        cat_findings["mesh_quality"].append(f)
+    for f in nr_find:
+        cat_findings["numerical_reliability"].append(f)
+    for f in pv_find:
+        cat_findings["physical_validity"].append(f)
+    for f in acc_find:
+        cat_findings["accuracy_vs_reference"].append(f)
+    for f in rep_find:
+        cat_findings["engineering_reporting"].append(f)
+    for f in mb_find:
+        cat_findings["mesh_budget"].append(f)
+    for f in submission_findings:
+        cat_findings.setdefault(f.category, []).append(f)
+
+    # Each category's raw score = the evaluator's base score MINUS only the
+    # penalties from cross-cutting submission findings routed into it. The
+    # penalty-based evaluators already fold their own findings into their base
+    # (100 - own penalties); the score-based ones (accuracy, reporting) return a
+    # computed score, so we must not re-derive it from penalties.
+    cross_pen: dict[str, float] = {}
+    for f in submission_findings:
+        cross_pen[f.category] = cross_pen.get(f.category, 0.0) + f.penalty
+
+    base_scores = {
+        "problem_setup": ps_score,
+        "mesh_quality": mq_score,
+        "numerical_reliability": nr_score,
+        "physical_validity": pv_score,
+        "engineering_reporting": rep_score,
+    }
+    raw_scores = {cat: max(0.0, base - cross_pen.get(cat, 0.0))
+                  for cat, base in base_scores.items()}
+
+    # ---- weighting: score-based categories that can be N/A (accuracy, mesh_budget)
+    # have their weight redistributed across the rest when not applicable ----
+    weights = case.weights()
+    optional_scores = {"accuracy_vs_reference": acc_score, "mesh_budget": mb_score}
+    applicable: dict[str, bool] = {}
+    na_weight = 0.0
+    for cat, sc in optional_scores.items():
+        if sc is None:
+            na_weight += weights.pop(cat, 0.0)
+            raw_scores[cat] = 0.0
+            applicable[cat] = False
+        else:
+            raw_scores[cat] = max(0.0, sc - cross_pen.get(cat, 0.0))
+            applicable[cat] = True
+    if na_weight > 0.0:
+        tot = sum(weights.values())
+        if tot > 0.0:
+            weights = {k: v + v / tot * na_weight for k, v in weights.items()}
+    accuracy_applicable = applicable["accuracy_vs_reference"]
+
+    subscores: dict[str, float] = {}
+    subscores_details: dict[str, dict] = {}
+    weighted_total = 0.0
+    for cat in CATEGORIES:
+        w = weights.get(cat, 0.0)
+        raw = raw_scores.get(cat, 0.0)
+        ss = _subscore(cat, raw, w, cat_findings.get(cat, []))
+        subscores[cat] = ss.raw_score
+        subscores_details[cat] = ss.__dict__
+        weighted_total += ss.weighted_points
+
+    # ---- validity gate: any critical gate failure -> overall 0 -----------
+    all_findings = [f for fs in cat_findings.values() for f in fs]
+    failure_modes: list[dict] = []
+    gate_codes: list[str] = []
+    for f in all_findings:
+        if f.severity in ("major", "critical") and f.code in _KNOWN_FAILURE_CODES:
+            failure_modes.append({"code": f.code, "severity": f.severity,
+                                  "category": f.category, "evidence": f.message})
+        if f.severity == "critical" and f.code in CRITICAL_GATES:
+            gate_codes.append(f.code)
+
+    gates_triggered = [{"reason": c} for c in dict.fromkeys(gate_codes)]
+    overall = 0.0 if gate_codes else weighted_total
+    overall = max(0.0, min(100.0, overall))
+    grade = grade_from_score(overall)
+
+    # ---- flags -----------------------------------------------------------
+    repro = validators.reproducibility_status(submission)
+    crit_codes = {f.code for f in all_findings if f.severity == "critical"}
+    flags = {
+        "setup_correct": raw_scores["problem_setup"] >= 70 and
+                         "WRONG_ANALYSIS_TYPE" not in crit_codes and
+                         "MISSING_BOUNDARY_CONDITION" not in crit_codes,
+        "mesh_adequate": raw_scores["mesh_quality"] >= 60 and "INVERTED_ELEMENTS" not in crit_codes,
+        "numerically_reliable": "SOLVER_NOT_CONVERGED" not in crit_codes and
+                                "HALLUCINATED_CONVERGENCE" not in crit_codes and
+                                "REACTION_IMBALANCE" not in crit_codes and
+                                "INTERNAL_INCONSISTENCY" not in crit_codes,
+        "physically_valid": "PHYSICALLY_IMPOSSIBLE" not in crit_codes and
+                            "FREQ_NONPHYSICAL" not in crit_codes and
+                            "BUCKLING_NONPHYSICAL" not in crit_codes,
+        "accurate_vs_reference": accuracy_applicable and all(
+            c["within_tol"] for c in comparisons if c["critical"]) if comparisons else None,
+        "reproducible": repro == "reproducible",
+        "not_hallucinated": not ({"HALLUCINATED_SOLVER_OUTPUT", "UNVERIFIED_SOLVER_OUTPUT",
+                                  "HALLUCINATED_CONVERGENCE", "INTERNAL_INCONSISTENCY"}
+                                 & crit_codes),
+        "mesh_within_budget": (raw_scores["mesh_budget"] > 0.0)
+                              if applicable["mesh_budget"] else None,
+    }
+
+    # ---- feedback & fixes ------------------------------------------------
+    feedback: list[str] = []
+    fixes: list[str] = []
+    seen_fix = set()
+    for f in sorted(all_findings, key=lambda x: {"critical": 0, "major": 1, "minor": 2, "info": 3}[x.severity]):
+        if f.severity in ("critical", "major"):
+            feedback.append(f"[{f.severity.upper()}/{f.category}] {f.message}")
+        if f.code in SUGGESTED_FIXES and f.code not in seen_fix and f.severity in ("critical", "major"):
+            fixes.append(SUGGESTED_FIXES[f.code])
+            seen_fix.add(f.code)
+    if not feedback:
+        feedback.append("No major or critical issues detected; result looks sound on the checked axes.")
+
+    # ---- confidence ------------------------------------------------------
+    confidence = _confidence(submission, accuracy_applicable, conv)
+
+    # ---- evidence summary ------------------------------------------------
+    evidence = _evidence(case, submission, conv, comparisons, accuracy_applicable)
+
+    return ScoringReport(
+        case_id=case.case_id,
+        overall_score=round(overall, 1),
+        grade=grade,
+        subscores=subscores,
+        subscores_details=subscores_details,
+        pass_fail_flags=flags,
+        failure_modes_detected=_dedup_failures(failure_modes),
+        gates_triggered=gates_triggered,
+        numerical_comparisons=comparisons,
+        engineering_feedback=feedback,
+        suggested_fixes=fixes,
+        confidence=round(confidence, 2),
+        reproducibility_status=repro,
+        evidence=evidence,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# helpers                                                                     #
+# --------------------------------------------------------------------------- #
+_KNOWN_FAILURE_CODES = set(CRITICAL_GATES) | {
+    "POOR_MESH_QUALITY", "NO_CONVERGENCE_STUDY", "MESH_NOT_CONVERGED", "ENERGY_IMBALANCE",
+    "ACCURACY_GROSS_ERROR", "LARGE_DEFLECTION", "PARTIAL_REPRODUCIBILITY", "INCOMPLETE_REPORT",
+    "HIGH_RESIDUAL", "UNDER_RESOLVED", "MATERIAL_NOT_STATED", "BC_COUNT_LOW",
+    "MESH_BUDGET_EXCEEDED", "MESH_BUDGET_OVER", "MESH_BUDGET_UNDERRESOLVED",
+}
+
+
+def _dedup_failures(failures: list[dict]) -> list[dict]:
+    seen = set()
+    out = []
+    for f in failures:
+        key = (f["code"], f["category"])
+        if key not in seen:
+            seen.add(key)
+            out.append(f)
+    return out
+
+
+def _confidence(submission: Submission, accuracy_applicable: bool, conv: dict) -> float:
+    """How much the scorer trusts its own verdict given the evidence available."""
+    c = 1.0
+    if not submission.solver:
+        c -= 0.15
+    if not submission.units:
+        c -= 0.05
+    if not (submission.mesh or {}).get("quality"):
+        c -= 0.1
+    if not accuracy_applicable:
+        c -= 0.1
+    if conv.get("n_grids", 0) < 2:
+        c -= 0.05
+    if not submission.artifacts:
+        c -= 0.1
+    return max(0.3, c)
+
+
+def _evidence(case, submission, conv, comparisons, accuracy_applicable) -> list[str]:
+    ev = []
+    ev.append(f"analysis_type: required={case.analysis_type}, submitted={submission.analysis_type or 'n/a'}")
+    if conv.get("n_grids"):
+        ev.append(f"convergence: {conv['n_grids']} grids, converged={conv.get('converged')}, "
+                  f"last_change={conv.get('last_rel_change')}, GCI={conv.get('gci_fine')}")
+    if accuracy_applicable:
+        for c in comparisons:
+            ev.append(f"ref[{c['quantity']}]: claimed={c['claimed']} vs {c['reference']} {c['unit']} "
+                      f"(err={c['rel_error']}, within_tol={c['within_tol']}, {c['method']})")
+    repro = (submission.artifacts or {})
+    ev.append(f"artifacts: {sorted(k for k, v in repro.items() if v)}")
+    return ev

--- a/src/freecad_validator/fem/step_interface.py
+++ b/src/freecad_validator/fem/step_interface.py
@@ -1,0 +1,712 @@
+"""Validate a solved FEM candidate against an engineer-generated reference.
+
+Inputs (all required):
+* ``step_path``            - the source 3D geometry that was to be analysed (STEP).
+* ``fcstd_path_reference`` - the solved reference FCStd.
+* ``fcstd_path_candidate`` - the solved candidate FCStd to validate.
+
+What it evaluates on the candidate:
+* geometry fidelity     - did the candidate analyse the STEP solid (volume match)?
+* accuracy vs reference - candidate result quantities vs the reference values;
+* mesh budget           - candidate element count vs the reference baseline;
+* problem-setup match   - analysis type, material, restraint, and load;
+* physical validity, mesh quality, numerical reliability of the candidate.
+
+Returns a ``ScoringReport`` (the standard type): overall 0-100, per-category
+sub-scores, pass/fail flags, detected failure modes, numerical comparison table
+(candidate vs reference), feedback, confidence and reproducibility status.
+
+A raw FCStd carries no convergence study or written report, so those categories
+are weighted out. Accuracy-vs-reference is the largest single weight; a gross miss on
+the critical quantity caps the score (a failed reproduction); a geometry mismatch
+or a physically impossible result hard-caps the score regardless.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from freecad_validator._freecad_loader import resolve_freecad_command
+from freecad_validator.fem.schema import (
+    DISP_TOL,
+    GROSS_TOL,
+    MESH_BUDGET_ZERO_RATIO,
+    STRESS_TOL,
+    CaseDefinition,
+    FailureMode,
+    ScoringReport,
+    Submission,
+)
+from freecad_validator.fem.scorer import score_result
+
+HERE = Path(__file__).resolve().parent
+FCSTD_ADAPTER = str(HERE / "adapters" / "fcstd.py")
+STEP_ADAPTER = str(HERE / "adapters" / "step.py")
+
+
+class ExtractionError(RuntimeError):
+    """An adapter could not produce a valid extraction payload."""
+
+
+class RuntimeEnvironmentError(ExtractionError):
+    """The validator runtime is missing or misconfigured."""
+
+
+DEFAULT_SUBPROCESS_TIMEOUT_SECONDS = 900.0
+DIAGNOSTIC_TAIL_CHARACTERS = 16_000
+
+
+# Accuracy-vs-reference is the largest single weight; mesh_budget (candidate element
+# count vs the reference's) is a deliberate 25% efficiency factor. A raw FCStd carries
+# no report/convergence study, so those stay at 0.
+PREPROCESSING_VOLUME_REL_TOL = 1e-3
+PREPROCESSING_SURFACE_AREA_REL_TOL = 1e-2
+BOOLEAN_TOPOLOGY_FIELDS = (
+    "num_solids",
+    "num_compsolids",
+    "shape_types",
+    "num_faces",
+    "num_edges",
+)
+BOOLEAN_CONTAINER_FIELDS = ("num_compsolids", "shape_types")
+BOOLEAN_REGION_INTEGER_FIELDS = ("num_faces", "num_edges", "num_shells")
+BOOLEAN_REGION_FLOAT_FIELDS = ("volume_mm3", "surface_area_mm2")
+BOOLEAN_TOPOLOGY_REL_TOL = 1e-5
+
+
+def _relative_difference(left: float, right: float) -> float:
+    return abs(left - right) / max(abs(left), abs(right), 1e-9)
+
+
+def _preprocessing_gate_report(
+    input_geometry: dict[str, Any], candidate_geometry: dict[str, Any]
+) -> ScoringReport | None:
+    """Return an immediate zero when candidate geometry matches the input STEP."""
+    keys = ("volume_mm3", "surface_area_mm2")
+    if not all(float(input_geometry.get(key, 0.0) or 0.0) > 0.0 for key in keys):
+        return None
+    if not all(float(candidate_geometry.get(key, 0.0) or 0.0) > 0.0 for key in keys):
+        return None
+
+    volume_diff = _relative_difference(
+        float(input_geometry["volume_mm3"]),
+        float(candidate_geometry["volume_mm3"]),
+    )
+    area_diff = _relative_difference(
+        float(input_geometry["surface_area_mm2"]),
+        float(candidate_geometry["surface_area_mm2"]),
+    )
+    if (
+        volume_diff > PREPROCESSING_VOLUME_REL_TOL
+        or area_diff > PREPROCESSING_SURFACE_AREA_REL_TOL
+    ):
+        return None
+
+    message = (
+        "Candidate volume and surface area match the input STEP; "
+        "required geometry preprocessing was not performed."
+    )
+    failure = {
+        "code": FailureMode.PREPROCESSING_NOT_PERFORMED,
+        "severity": "critical",
+        "category": "problem_setup",
+        "evidence": message,
+    }
+    return ScoringReport(
+        case_id="step+reference+candidate",
+        overall_score=0.0,
+        grade="invalid",
+        subscores={"problem_setup": 0.0},
+        pass_fail_flags={"setup_correct": False},
+        failure_modes_detected=[failure],
+        gates_triggered=[{"reason": FailureMode.PREPROCESSING_NOT_PERFORMED}],
+        engineering_feedback=[f"[CRITICAL/problem_setup] {message}"],
+        suggested_fixes=[
+            "Apply the required geometry preprocessing before creating and solving the FEM model."
+        ],
+        confidence=1.0,
+        reproducibility_status="not_evaluated",
+        evidence=[
+            "preprocessing_gate: input STEP and candidate geometry match",
+            f"preprocessing_volume_rel_diff: {volume_diff:.6g}",
+            f"preprocessing_surface_area_rel_diff: {area_diff:.6g}",
+        ],
+    )
+
+
+def _boolean_topology_signature(
+    geometry: dict[str, Any], source: str
+) -> dict[str, Any]:
+    missing = [field for field in BOOLEAN_TOPOLOGY_FIELDS if field not in geometry]
+    if "regions" not in geometry:
+        missing.append("regions")
+    if missing:
+        raise ExtractionError(
+            f"{source} geometry is missing Boolean topology fields: "
+            + ", ".join(missing)
+        )
+    if not isinstance(geometry["regions"], list):
+        raise ExtractionError(f"{source} geometry Boolean field 'regions' is not a list")
+    return {
+        **{field: geometry[field] for field in BOOLEAN_TOPOLOGY_FIELDS},
+        "regions": geometry["regions"],
+    }
+
+
+def _boolean_regions_match(expected: Any, actual: Any) -> bool:
+    if not isinstance(expected, dict) or not isinstance(actual, dict):
+        return False
+    if any(
+        expected.get(field) != actual.get(field)
+        for field in BOOLEAN_REGION_INTEGER_FIELDS
+    ):
+        return False
+    for field in BOOLEAN_REGION_FLOAT_FIELDS:
+        expected_value = expected.get(field)
+        actual_value = actual.get(field)
+        if not isinstance(expected_value, (int, float)) or not isinstance(
+            actual_value, (int, float)
+        ):
+            return False
+        if (
+            _relative_difference(float(expected_value), float(actual_value))
+            > BOOLEAN_TOPOLOGY_REL_TOL
+        ):
+            return False
+    return True
+
+
+def _boolean_topology_mismatches(
+    expected: dict[str, Any], actual: dict[str, Any]
+) -> list[str]:
+    mismatches = []
+    for field in BOOLEAN_TOPOLOGY_FIELDS:
+        if expected.get(field) != actual.get(field):
+            mismatches.append(
+                f"{field}: expected {expected.get(field)!r}, got {actual.get(field)!r}"
+            )
+
+    expected_regions = expected.get("regions")
+    actual_regions = actual.get("regions")
+    if not isinstance(expected_regions, list) or not isinstance(actual_regions, list):
+        mismatches.append("regions: missing or invalid region list")
+        return mismatches
+    if len(expected_regions) != len(actual_regions):
+        mismatches.append(
+            f"regions: expected {len(expected_regions)}, got {len(actual_regions)}"
+        )
+        return mismatches
+
+    unmatched_actual = list(actual_regions)
+    for index, expected_region in enumerate(expected_regions):
+        matching_index = next(
+            (
+                actual_index
+                for actual_index, actual_region in enumerate(unmatched_actual)
+                if _boolean_regions_match(expected_region, actual_region)
+            ),
+            None,
+        )
+        if matching_index is None:
+            mismatches.append(f"regions[{index}]: no matching candidate region")
+        else:
+            unmatched_actual.pop(matching_index)
+    return mismatches
+
+
+def _boolean_minimum_reference_mismatches(
+    reference: dict[str, Any], candidate: dict[str, Any]
+) -> list[str]:
+    """Compare only the topology requirements needed to prove Boolean output."""
+    mismatches = []
+    reference_regions = reference["regions"]
+    candidate_regions = candidate["regions"]
+    if len(reference_regions) != len(candidate_regions):
+        mismatches.append(
+            f"regions: expected {len(reference_regions)}, got {len(candidate_regions)}"
+        )
+    for field in BOOLEAN_CONTAINER_FIELDS:
+        if reference[field] != candidate[field]:
+            mismatches.append(
+                f"{field}: expected {reference[field]!r}, got {candidate[field]!r}"
+            )
+    return mismatches
+
+
+def _boolean_failure_report(
+    failure_mode: str, message: str, evidence: list[str]
+) -> ScoringReport:
+    return ScoringReport(
+        case_id="step+reference+candidate",
+        overall_score=0.0,
+        grade="invalid",
+        subscores={"problem_setup": 0.0},
+        pass_fail_flags={"setup_correct": False},
+        failure_modes_detected=[{
+            "code": failure_mode,
+            "severity": "critical",
+            "category": "problem_setup",
+            "evidence": message,
+        }],
+        gates_triggered=[{"reason": failure_mode}],
+        engineering_feedback=[f"[CRITICAL/problem_setup] {message}"],
+        suggested_fixes=[
+            "Apply Boolean Fragments and preserve the required region/container topology."
+        ],
+        confidence=1.0,
+        reproducibility_status="not_evaluated",
+        evidence=evidence,
+    )
+
+
+def _boolean_gate_report(
+    source_geometry: dict[str, Any],
+    reference_geometry: dict[str, Any],
+    candidate_geometry: dict[str, Any],
+) -> ScoringReport | None:
+    source_signature = _boolean_topology_signature(source_geometry, "source STEP")
+    reference_signature = _boolean_topology_signature(
+        reference_geometry, "reference FCStd"
+    )
+    if not _boolean_topology_mismatches(source_signature, reference_signature):
+        raise ExtractionError(
+            "need_boolean is true, but source STEP and reference FCStd Boolean "
+            "topologies are indistinguishable"
+        )
+    try:
+        candidate_signature = _boolean_topology_signature(
+            candidate_geometry, "candidate FCStd"
+        )
+    except ExtractionError as exc:
+        return _boolean_failure_report(
+            FailureMode.GEOMETRY_MISMATCH,
+            "Candidate geometry could not satisfy the required Boolean topology.",
+            [f"boolean_candidate_geometry_error: {exc}"],
+        )
+
+    if not _boolean_topology_mismatches(source_signature, candidate_signature):
+        return _boolean_failure_report(
+            FailureMode.BOOLEAN_NOT_PERFORMED,
+            "Candidate topology still matches the raw STEP; required Boolean "
+            "Fragments were not performed.",
+            ["boolean_gate: candidate topology matches source STEP"],
+        )
+
+    reference_mismatches = _boolean_minimum_reference_mismatches(
+        reference_signature, candidate_signature
+    )
+    if reference_mismatches:
+        evidence = ["boolean_gate: candidate topology differs from reference FCStd"]
+        evidence.extend(reference_mismatches[:20])
+        return _boolean_failure_report(
+            FailureMode.GEOMETRY_MISMATCH,
+            "Candidate Boolean region/container topology differs from the reference.",
+            evidence,
+        )
+    return None
+
+
+STEP_WEIGHTS = {
+    "accuracy_vs_reference": 0.35,
+    "mesh_budget": 0.25,            # candidate elements vs reference baseline (0 at >=130%)
+    "problem_setup": 0.15,          # incl. geometry fidelity + analysis/material/BC/load match
+    "physical_validity": 0.15,
+    "numerical_reliability": 0.05,
+    "mesh_quality": 0.05,
+    "engineering_reporting": 0.0,
+}
+
+
+def _reference_quantities(reference_sub: dict[str, Any], disp_tol: float, stress_tol: float) -> dict[str, Any]:
+    res = reference_sub.get("results", {})
+    q: dict[str, Any] = {}
+    if "max_displacement_mm" in res:
+        q["max_displacement_mm"] = {"value": res["max_displacement_mm"], "unit": "mm",
+                                    "tol_rel": disp_tol, "critical": True}
+    if "max_von_mises_MPa" in res:
+        q["max_von_mises_MPa"] = {"value": res["max_von_mises_MPa"], "unit": "MPa",
+                                  "tol_rel": stress_tol, "critical": False}
+    if "max_shear_MPa" in res:
+        q["max_shear_MPa"] = {"value": res["max_shear_MPa"], "unit": "MPa",
+                              "tol_rel": stress_tol, "critical": False}
+    freqs = res.get("natural_frequencies_Hz")
+    if freqs:
+        q["first_natural_frequency_Hz"] = {"value": freqs[0], "unit": "Hz",
+                                           "tol_rel": disp_tol, "critical": True}
+    return q
+
+
+def build_case(target_geom: dict[str, Any], reference_sub: dict[str, Any],
+               disp_tol: float = DISP_TOL, stress_tol: float = STRESS_TOL,
+               gross_tol: float = GROSS_TOL,
+               mesh_budget_zero_ratio: float = MESH_BUDGET_ZERO_RATIO,
+               case_id: str = "step+reference+candidate") -> CaseDefinition:
+    """Build from target geometry and an engineer-generated reference.
+
+    The reference element count is the mesh-budget baseline.
+    """
+    geometry = {k: target_geom[k] for k in ("volume_mm3", "bbox_mm", "characteristic_length_mm")
+                if k in target_geom}
+    mesh_exp: dict[str, Any] = {"expect_convergence": False}
+    baseline = (reference_sub.get("mesh") or {}).get("num_elements")
+    if baseline:
+        mesh_exp["baseline_num_elements"] = baseline
+        mesh_exp["budget_zero_ratio"] = mesh_budget_zero_ratio
+    return CaseDefinition(
+        case_id=case_id, title="geometry + reference + candidate evaluation",
+        category="fem", subtype="",
+        analysis_type=reference_sub.get("analysis_type", "static"),
+        units_expected={"length": "mm", "force": "N", "stress": "MPa"},
+        geometry=geometry, material=dict(reference_sub.get("material", {})),
+        expected_bcs=reference_sub.get("boundary_conditions") or [{"type": "fixed"}],
+        expected_loads=reference_sub.get("loads") or [],
+        reference={"method": "numerical", "source": "engineer-generated solved FCStd",
+                   "quantities": _reference_quantities(reference_sub, disp_tol, stress_tol),
+                   "gross_tol": gross_tol},
+        mesh_expectations=mesh_exp,
+        weights_override=dict(STEP_WEIGHTS), rubric={"requires_safety_factor": False})
+
+
+def score_trusted_payloads(target_geom: dict[str, Any], reference_sub: dict[str, Any],
+                          candidate_sub: dict[str, Any], disp_tol: float = DISP_TOL,
+                          stress_tol: float = STRESS_TOL, gross_tol: float = GROSS_TOL,
+                          mesh_budget_zero_ratio: float = MESH_BUDGET_ZERO_RATIO,
+                          geometry_source: str = "STEP") -> ScoringReport:
+    """Score validator-generated extraction payloads without FreeCAD.
+
+    This is a trusted low-level API. All three dictionaries must come directly
+    from validator-controlled adapters or equivalent protected code. Never pass
+    candidate-controlled JSON here; replay-verification fields are trusted.
+    """
+    case = build_case(target_geom, reference_sub, disp_tol, stress_tol, gross_tol,
+                      mesh_budget_zero_ratio)
+    sub = Submission.from_dict({**candidate_sub, "case_id": case.case_id})
+    report = score_result(case, sub)
+
+    report.evidence.insert(
+        0,
+        f"evaluation_mode: reference-based ({geometry_source} target + engineer reference + candidate)",
+    )
+    extraction_failure = (candidate_sub.get("meta") or {}).get("candidate_extraction_failure")
+    if extraction_failure:
+        report.evidence.insert(1, f"candidate_extraction_failure: {extraction_failure}")
+    sv, fv = target_geom.get("volume_mm3"), sub.geometry.get("volume_mm3")
+    if sv and fv:
+        report.evidence.insert(1, f"geometry_fidelity: target_volume={sv:.0f} mm^3, "
+                                  f"candidate_volume={fv:.0f} mm^3")
+    base_n = (reference_sub.get("mesh") or {}).get("num_elements")
+    cand_n = (candidate_sub.get("mesh") or {}).get("num_elements")
+    if base_n and cand_n:
+        report.evidence.insert(2, f"mesh_budget: candidate={cand_n} elements vs reference baseline="
+                                  f"{base_n} ({cand_n/base_n*100:.0f}%; 0 at "
+                                  f"{mesh_budget_zero_ratio*100:.0f}%)")
+    return report
+
+
+def _terminate_process_tree(process: subprocess.Popen) -> None:
+    if process.poll() is not None:
+        return
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    else:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=10)
+
+
+def _diagnostic_tail(log_path: str) -> str:
+    try:
+        with open(log_path, "rb") as log_file:
+            log_file.seek(0, os.SEEK_END)
+            size = log_file.tell()
+            log_file.seek(max(0, size - DIAGNOSTIC_TAIL_CHARACTERS))
+            return log_file.read().decode("utf-8", errors="replace").strip()
+    except OSError:
+        return ""
+
+
+def _run_adapter(
+    freecad_cmd: str,
+    adapter: str,
+    out_path: str,
+    adapter_args: list[str],
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    if not os.path.exists(freecad_cmd):
+        raise ExtractionError(
+            f"FreeCAD not found at {freecad_cmd!r}; set FREECAD_CMD to your FreeCAD 1.1 freecadcmd.")
+    if timeout_seconds <= 0.0:
+        raise ValueError("timeout_seconds must be positive")
+    log_path = f"{out_path}.log"
+    try:
+        if os.path.exists(out_path):
+            os.remove(out_path)
+        command = [freecad_cmd, adapter, *adapter_args, out_path]
+        popen_options: dict[str, Any] = {}
+        if os.name == "nt":
+            popen_options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            popen_options["start_new_session"] = True
+        with open(log_path, "w", encoding="utf-8") as log_file:
+            process = subprocess.Popen(
+                command,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                text=True,
+                **popen_options,
+            )
+            try:
+                return_code = process.wait(timeout=timeout_seconds)
+            except subprocess.TimeoutExpired as exc:
+                _terminate_process_tree(process)
+                raise ExtractionError(
+                    f"adapter timed out after {timeout_seconds:g} seconds"
+                ) from exc
+        if return_code != 0 or not os.path.exists(out_path):
+            diagnostic = _diagnostic_tail(log_path)
+            detail = diagnostic or "adapter produced no diagnostic output"
+            raise ExtractionError(
+                f"adapter failed with exit {return_code}: {detail}")
+        with open(out_path, encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except ExtractionError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ExtractionError(f"adapter extraction failed: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ExtractionError("adapter JSON is not an object")
+    return payload
+
+
+def _extract(
+    freecad_cmd: str,
+    adapter: str,
+    in_path: str,
+    out_path: str,
+    extra_args: list[str] | None = None,
+    timeout_seconds: float = DEFAULT_SUBPROCESS_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    adapter_args = [os.path.abspath(in_path), *(extra_args or [])]
+    try:
+        return _run_adapter(
+            freecad_cmd,
+            adapter,
+            out_path,
+            adapter_args,
+            timeout_seconds,
+        )
+    except ExtractionError as exc:
+        raise ExtractionError(f"extraction failed for {in_path}: {exc}") from exc
+
+
+def _runtime_preflight(
+    freecad_cmd: str,
+    extract_dir: str,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    out_path = os.path.join(extract_dir, "fem_runtime.json")
+    try:
+        payload = _run_adapter(
+            freecad_cmd,
+            FCSTD_ADAPTER,
+            out_path,
+            ["runtime-info"],
+            min(timeout_seconds, 30.0),
+        )
+    except (ExtractionError, ValueError) as exc:
+        raise RuntimeEnvironmentError(f"FEM runtime preflight failed: {exc}") from exc
+    runtime = payload.get("runtime")
+    if not isinstance(runtime, dict) or not runtime.get("calculix"):
+        raise RuntimeEnvironmentError(
+            "FEM runtime preflight produced no CalculiX version"
+        )
+    return runtime
+
+
+def _failed_candidate(reason: str) -> dict[str, Any]:
+    return {
+        "solver": {"converged": False},
+        "results": {},
+        "artifacts": {},
+        "meta": {"candidate_extraction_failure": reason},
+    }
+
+
+def _score_step_fcstd(
+    step_path: str,
+    fcstd_path_reference: str,
+    fcstd_path_candidate: str,
+    freecad_cmd: str,
+    extract_dir: str,
+    disp_tol: float,
+    stress_tol: float,
+    gross_tol: float,
+    mesh_budget_zero_ratio: float,
+    require_preprocessing: bool,
+    require_boolean: bool,
+    timeout_seconds: float,
+    runtime_provenance: dict[str, Any],
+) -> ScoringReport:
+    fc = freecad_cmd
+    os.makedirs(extract_dir, exist_ok=True)
+    tag = os.path.splitext(os.path.basename(fcstd_path_candidate))[0]
+    step_geom = _extract(
+        fc, STEP_ADAPTER, step_path, os.path.join(extract_dir, f"{tag}_step.json"),
+        timeout_seconds=timeout_seconds,
+    )
+    reference_geometry_payload = None
+    if require_boolean:
+        reference_geometry_payload = _extract(
+            fc, FCSTD_ADAPTER, fcstd_path_reference,
+            os.path.join(extract_dir, f"{tag}_boolean_reference.json"),
+            extra_args=["geometry-only"],
+            timeout_seconds=timeout_seconds,
+        )
+    candidate_geometry_payload = None
+    if require_preprocessing or require_boolean:
+        candidate_geometry_payload = _extract(
+            fc, FCSTD_ADAPTER, fcstd_path_candidate,
+            os.path.join(extract_dir, f"{tag}_required_geometry_candidate.json"),
+            extra_args=["geometry-only"],
+            timeout_seconds=timeout_seconds,
+        )
+    if require_preprocessing:
+        if candidate_geometry_payload is None:
+            raise ExtractionError("candidate geometry extraction was not performed")
+        gate_report = _preprocessing_gate_report(
+            step_geom,
+            candidate_geometry_payload.get("geometry") or {},
+        )
+        if gate_report is not None:
+            gate_report.runtime_provenance = dict(runtime_provenance)
+            return gate_report
+    if require_boolean:
+        if reference_geometry_payload is None or candidate_geometry_payload is None:
+            raise ExtractionError("Boolean geometry extraction was not performed")
+        gate_report = _boolean_gate_report(
+            step_geom,
+            reference_geometry_payload.get("geometry") or {},
+            candidate_geometry_payload.get("geometry") or {},
+        )
+        if gate_report is not None:
+            gate_report.runtime_provenance = dict(runtime_provenance)
+            return gate_report
+
+    reference = _extract(
+        fc,
+        FCSTD_ADAPTER,
+        fcstd_path_reference,
+        os.path.join(extract_dir, f"{tag}_reference.json"),
+        timeout_seconds=timeout_seconds,
+    )
+    if reference.get("no_result"):
+        reason = reference.get("extraction_error") or "no FEM result object found"
+        raise ExtractionError(f"reference FCStd contains no loaded FEM result: {reason}")
+    try:
+        candidate = _extract(fc, FCSTD_ADAPTER, fcstd_path_candidate,
+                             os.path.join(extract_dir, f"{tag}_candidate.json"),
+                             extra_args=["verify-solve"],
+                             timeout_seconds=timeout_seconds)
+    except ExtractionError as exc:
+        candidate = _failed_candidate(str(exc))
+    if candidate.get("no_result"):
+        reason = candidate.get("extraction_error") or "no FEM result object found"
+        candidate = _failed_candidate(reason)
+    target_geometry = step_geom
+    geometry_source = "STEP"
+    if require_preprocessing:
+        target_geometry = reference.get("geometry") or {}
+        if not target_geometry:
+            raise ExtractionError(
+                "reference FCStd contains no geometry for preprocessing validation"
+            )
+        geometry_source = "reference FCStd geometry"
+    report = score_trusted_payloads(
+        target_geometry,
+        reference,
+        candidate,
+        disp_tol,
+        stress_tol,
+        gross_tol,
+        mesh_budget_zero_ratio,
+        geometry_source,
+    )
+    report.runtime_provenance = dict(runtime_provenance)
+    return report
+
+
+def score_step_fcstd(
+    step_path: str,
+    fcstd_path_reference: str,
+    fcstd_path_candidate: str,
+    freecad_cmd: str | None = None,
+    extract_dir: str | None = None,
+    disp_tol: float = DISP_TOL,
+    stress_tol: float = STRESS_TOL,
+    gross_tol: float = GROSS_TOL,
+    mesh_budget_zero_ratio: float = MESH_BUDGET_ZERO_RATIO,
+    require_preprocessing: bool = False,
+    require_boolean: bool = False,
+    timeout_seconds: float = DEFAULT_SUBPROCESS_TIMEOUT_SECONDS,
+) -> ScoringReport:
+    """Extract and score one candidate against an engineer reference.
+
+    FreeCAD and CalculiX are required and execute in subprocesses. Run this API
+    in an isolated container when the candidate FCStd is untrusted. A missing or
+    broken runtime raises :class:`RuntimeEnvironmentError` before scoring.
+    """
+    if timeout_seconds <= 0.0:
+        raise ValueError("timeout_seconds must be positive")
+    fc = resolve_freecad_command(freecad_cmd)
+    if extract_dir is not None:
+        os.makedirs(extract_dir, exist_ok=True)
+        runtime_provenance = _runtime_preflight(fc, extract_dir, timeout_seconds)
+        return _score_step_fcstd(
+            step_path,
+            fcstd_path_reference,
+            fcstd_path_candidate,
+            fc,
+            extract_dir,
+            disp_tol,
+            stress_tol,
+            gross_tol,
+            mesh_budget_zero_ratio,
+            require_preprocessing,
+            require_boolean,
+            timeout_seconds,
+            runtime_provenance,
+        )
+    with tempfile.TemporaryDirectory(prefix="freecad-validator-fem-") as temp_dir:
+        runtime_provenance = _runtime_preflight(fc, temp_dir, timeout_seconds)
+        return _score_step_fcstd(
+            step_path,
+            fcstd_path_reference,
+            fcstd_path_candidate,
+            fc,
+            temp_dir,
+            disp_tol,
+            stress_tol,
+            gross_tol,
+            mesh_budget_zero_ratio,
+            require_preprocessing,
+            require_boolean,
+            timeout_seconds,
+            runtime_provenance,
+        )

--- a/src/freecad_validator/fem/validator.py
+++ b/src/freecad_validator/fem/validator.py
@@ -1,0 +1,99 @@
+"""Configured object-oriented entry point for FEM validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from freecad_validator.fem.schema import (
+    DISP_TOL,
+    GROSS_TOL,
+    MESH_BUDGET_ZERO_RATIO,
+    STRESS_TOL,
+    ScoringReport,
+)
+from freecad_validator.fem.step_interface import (
+    DEFAULT_SUBPROCESS_TIMEOUT_SECONDS,
+    score_step_fcstd,
+    score_trusted_payloads,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FEMValidator:
+    """Reusable configuration for deterministic FEM scoring.
+
+    The FCStd path runs FreeCAD and CalculiX subprocesses. Callers validating
+    untrusted candidate files should execute it in an isolated container.
+    """
+
+    freecad_cmd: str | None = None
+    extract_dir: str | None = None
+    displacement_tolerance: float = DISP_TOL
+    stress_tolerance: float = STRESS_TOL
+    gross_error_tolerance: float = GROSS_TOL
+    mesh_budget_zero_ratio: float = MESH_BUDGET_ZERO_RATIO
+    require_preprocessing: bool = False
+    require_boolean: bool = False
+    timeout_seconds: float = DEFAULT_SUBPROCESS_TIMEOUT_SECONDS
+
+    def __post_init__(self) -> None:
+        tolerances = {
+            "displacement_tolerance": self.displacement_tolerance,
+            "stress_tolerance": self.stress_tolerance,
+            "gross_error_tolerance": self.gross_error_tolerance,
+        }
+        for name, value in tolerances.items():
+            if value <= 0.0:
+                raise ValueError(f"{name} must be positive")
+        if self.mesh_budget_zero_ratio <= 1.0:
+            raise ValueError("mesh_budget_zero_ratio must be greater than 1.0")
+        if self.timeout_seconds <= 0.0:
+            raise ValueError("timeout_seconds must be positive")
+
+    def validate(
+        self,
+        *,
+        step_path: str,
+        reference_fcstd: str,
+        candidate_fcstd: str,
+    ) -> ScoringReport:
+        """Extract, replay, and score one candidate FCStd."""
+        return score_step_fcstd(
+            step_path,
+            reference_fcstd,
+            candidate_fcstd,
+            freecad_cmd=self.freecad_cmd,
+            extract_dir=self.extract_dir,
+            disp_tol=self.displacement_tolerance,
+            stress_tol=self.stress_tolerance,
+            gross_tol=self.gross_error_tolerance,
+            mesh_budget_zero_ratio=self.mesh_budget_zero_ratio,
+            require_preprocessing=self.require_preprocessing,
+            require_boolean=self.require_boolean,
+            timeout_seconds=self.timeout_seconds,
+        )
+
+    def validate_trusted_payloads(
+        self,
+        *,
+        target_geometry: dict[str, Any],
+        reference_submission: dict[str, Any],
+        candidate_submission: dict[str, Any],
+        geometry_source: str = "STEP",
+    ) -> ScoringReport:
+        """Score trusted, validator-generated payloads without FreeCAD.
+
+        Never pass candidate-controlled JSON to this low-level API because it
+        trusts replay-verification fields produced by the FCStd adapter.
+        """
+        return score_trusted_payloads(
+            target_geometry,
+            reference_submission,
+            candidate_submission,
+            disp_tol=self.displacement_tolerance,
+            stress_tol=self.stress_tolerance,
+            gross_tol=self.gross_error_tolerance,
+            mesh_budget_zero_ratio=self.mesh_budget_zero_ratio,
+            geometry_source=geometry_source,
+        )

--- a/src/freecad_validator/fem/validators.py
+++ b/src/freecad_validator/fem/validators.py
@@ -1,0 +1,867 @@
+"""Deterministic, rule-based checks - the backbone of the scorer.
+
+Each ``evaluate_*`` / ``validate_*`` function inspects the ``Submission`` against
+the ``CaseDefinition`` and returns ``(raw_score_0_100, [Finding, ...])`` for one
+scoring category, except ``detect_submission_failures`` which returns cross-cutting
+findings (consistency, reproducibility, hallucinated output, case mismatch)
+already tagged with the category they should score against.
+
+Critical findings carry a large category penalty AND a code in
+``schema.CRITICAL_GATES`` so the orchestrator gates the overall score to 0.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from freecad_validator.fem import metrics
+from freecad_validator.fem.schema import (
+    LOAD_DIR_ALIGNED_DEG,
+    LOAD_DIR_GATE_DEG,
+    LOAD_LOC_TOL,
+    LOAD_MAG_GROSS_TOL,
+    LOAD_MAG_TOL,
+    MESH_BUDGET_FLOOR_RATIO,
+    MESH_BUDGET_ZERO_RATIO,
+    CaseDefinition,
+    FailureMode,
+    Finding,
+    Submission,
+)
+
+# --------------------------------------------------------------------------- #
+# small helpers                                                               #
+# --------------------------------------------------------------------------- #
+RESTRAINT_TYPES = {"fixed", "clamped", "encastre", "pinned", "restraint",
+                   "displacement", "fixed_support", "support"}
+PARTIAL_RESTRAINT_TYPES = {"symmetry", "symmetric", "roller", "frictionless", "contact"}
+
+SHAPE_WORDS = ["cantilever", "simply supported", "plate with hole", "plate-with-hole",
+               "thick cylinder", "pressure vessel", "bracket", "shaft", "torsion",
+               "truss", "frame", "column", "buckling", "beam", "lug", "clevis",
+               "hook", "flange", "nozzle", "heat sink", "crank", "gearbox",
+               "housing", "implant", "disc", "disk", "sphere", "ring"]
+
+
+def _num(d: dict[str, Any], *keys: str) -> float | None:
+    """First present numeric value among ``keys`` in dict ``d``."""
+    for k in keys:
+        if k in d and isinstance(d[k], (int, float)):
+            return float(d[k])
+    return None
+
+
+def _magnitude(v: Any) -> float | None:
+    if isinstance(v, (int, float)):
+        return abs(float(v))
+    if isinstance(v, (list, tuple)) and v and all(isinstance(x, (int, float)) for x in v):
+        return math.sqrt(sum(float(x) ** 2 for x in v))
+    return None
+
+
+def _score_from(findings: list[Finding]) -> float:
+    return max(0.0, 100.0 - sum(f.penalty for f in findings))
+
+
+def _norm_analysis(a: str) -> str:
+    a = (a or "").lower()
+    if "modal" in a or "frequency" in a or "eigen" in a or "vibrat" in a:
+        return "modal"
+    if "buckl" in a:
+        return "buckling"
+    if "thermal" in a and "mech" in a:
+        return "thermal_mechanical"
+    if "thermal" in a or "heat" in a:
+        return "thermal"
+    if "transient" in a or "dynamic" in a or "explicit" in a:
+        return "transient"
+    if "nonlinear" in a and ("mat" in a or "plast" in a):
+        return "nonlinear_material"
+    if "large" in a or "geom" in a:
+        return "large_deformation"
+    if "static" in a or "linear" in a or "stress" in a:
+        return "static"
+    return a or "static"
+
+
+def _has_restraint(bcs: list[dict[str, Any]]) -> tuple[bool, bool]:
+    """(has_full_restraint, has_partial_restraint)."""
+    full = any((b.get("type", "").lower() in RESTRAINT_TYPES) for b in bcs)
+    partial = any((b.get("type", "").lower() in PARTIAL_RESTRAINT_TYPES) for b in bcs)
+    return full, partial
+
+
+def _dist(a: list[float], b: list[float]) -> float:
+    return math.sqrt(sum((a[i] - b[i]) ** 2 for i in range(3)))
+
+
+def _norm(v: list[float]) -> float:
+    return math.sqrt(sum(x * x for x in v))
+
+
+def _loc(centroid: list[float] | None) -> str:
+    return ("unlocated" if centroid is None
+            else f"({centroid[0]:.0f}, {centroid[1]:.0f}, {centroid[2]:.0f}) mm")
+
+
+def _cluster_loads(loads: list[dict[str, Any]], kind: str, mag_keys: tuple[str, ...],
+                   cluster_tol: float) -> list[dict[str, Any]]:
+    """Group `kind` loads into per-location clusters (one loaded face/edge), summing the
+    component forces at each location into a net vector. Loads with no resolved centroid
+    collapse into a single 'unlocated' cluster, so the comparison degrades gracefully to
+    the net-aggregate when the adapter could not resolve locations. Each cluster carries
+    its centroid, summed magnitude, and net force vector (None if a member lacks direction)."""
+    clusters: list[dict[str, Any]] = []
+    for ld in loads:
+        if ld.get("type") != kind:
+            continue
+        mag = _num(ld, *mag_keys)
+        if mag is None:
+            continue
+        c = ld.get("centroid")
+        c = [float(x) for x in c] if isinstance(c, (list, tuple)) and len(c) == 3 else None
+        d = ld.get("direction")
+        d = [float(x) for x in d] if isinstance(d, (list, tuple)) and len(d) == 3 else None
+        host = next((cl for cl in clusters
+                     if (cl["centroid"] is None) == (c is None)
+                     and (c is None or _dist(cl["centroid"], c) <= cluster_tol)), None)
+        if host is None:
+            host = {"centroid": c, "vec": [0.0, 0.0, 0.0], "mag": 0.0, "_dir": True}
+            clusters.append(host)
+        host["mag"] += abs(mag)
+        if d is None:
+            host["_dir"] = False
+        else:
+            host["vec"] = [host["vec"][i] + mag * d[i] for i in range(3)]
+    for cl in clusters:
+        if not cl["_dir"]:
+            cl["vec"] = None
+    return clusters
+
+
+def _match_clusters(exp: list[dict[str, Any]], got: list[dict[str, Any]], match_tol: float):
+    """Greedy nearest-centroid pairing of loaded locations (closest pair first); the
+    unlocated clusters match each other. Returns (pairs, unmatched_expected, unmatched_got)."""
+    candidates = []
+    for i, e in enumerate(exp):
+        for j, g in enumerate(got):
+            if (e["centroid"] is None) != (g["centroid"] is None):
+                continue
+            d = 0.0 if e["centroid"] is None else _dist(e["centroid"], g["centroid"])
+            if e["centroid"] is None or d <= match_tol:
+                candidates.append((d, i, j))
+    used_e: set = set()
+    used_g: set = set()
+    pairs = []
+    for _, i, j in sorted(candidates):
+        if i not in used_e and j not in used_g:
+            used_e.add(i)
+            used_g.add(j)
+            pairs.append((exp[i], got[j]))
+    unmatched_e = [e for i, e in enumerate(exp) if i not in used_e]
+    unmatched_g = [g for j, g in enumerate(got) if j not in used_g]
+    return pairs, unmatched_e, unmatched_g
+
+
+def _mag_finding(got_m: float, exp_m: float, kind: str, unit: str, loc: str,
+                 findings: list[Finding], cat: str) -> None:
+    """Compare two load magnitudes at one location; a gross miss gates."""
+    if exp_m <= 0:
+        return
+    err = metrics.relative_error(got_m, exp_m)
+    where = "" if loc == "unlocated" else f" at {loc}"
+    if err > LOAD_MAG_GROSS_TOL:
+        findings.append(Finding(cat, FailureMode.WRONG_LOAD, "critical",
+                                f"Applied {kind} {got_m:g} {unit}{where} differs from the reference's "
+                                f"{exp_m:g} {unit} by {err*100:.0f}% - wrong load.", penalty=80))
+    elif err > LOAD_MAG_TOL:
+        findings.append(Finding(cat, FailureMode.WRONG_LOAD, "major",
+                                f"Applied {kind} {got_m:g} {unit}{where} differs from the reference's "
+                                f"{exp_m:g} {unit} by {err*100:.0f}%.", penalty=30))
+
+
+def _compare_force_pair(e: dict[str, Any], g: dict[str, Any],
+                        findings: list[Finding], cat: str) -> None:
+    """Compare one matched loaded face: net force magnitude, then direction. Falls back to
+    summed magnitude when direction is unavailable or the reference's net force is ~zero."""
+    loc = _loc(e["centroid"])
+    where = "" if loc == "unlocated" else f" at {loc}"
+    if e["vec"] is None or g["vec"] is None or _norm(e["vec"]) < 1e-9:
+        _mag_finding(g["mag"], e["mag"], "force", "N", loc, findings, cat)
+        return
+    _mag_finding(_norm(g["vec"]), _norm(e["vec"]), "force", "N", loc, findings, cat)
+    ang = _angle_deg(e["vec"], g["vec"])
+    if ang is None:
+        return
+    if ang >= LOAD_DIR_GATE_DEG:
+        # past the tight alignment bound the load points the wrong way -> wrong problem.
+        findings.append(Finding(cat, FailureMode.WRONG_LOAD, "critical",
+                                f"Applied force direction is {ang:.0f} deg from the reference's{where} - wrong "
+                                "load direction.", penalty=80))
+    elif ang > LOAD_DIR_ALIGNED_DEG:
+        # small offset: a real direction error, but not yet a different problem.
+        findings.append(Finding(cat, FailureMode.WRONG_LOAD, "major",
+                                f"Applied force direction is {ang:.0f} deg from the reference's{where}.",
+                                penalty=30))
+
+
+def _angle_deg(a: list[float], b: list[float]) -> float | None:
+    la = math.sqrt(sum(x * x for x in a))
+    lb = math.sqrt(sum(x * x for x in b))
+    if la < 1e-12 or lb < 1e-12:
+        return None
+    cos = sum(a[i] * b[i] for i in range(3)) / (la * lb)
+    return math.degrees(math.acos(max(-1.0, min(1.0, cos))))
+
+
+def _compare_loads(expected: list[dict[str, Any]], got: list[dict[str, Any]],
+                   cat: str, char_len: float | None) -> list[Finding]:
+    """Check the candidate reproduces the LABEL's loading, MATCHING loads by location
+    first: each side's loads are clustered per loaded face (component forces summed into a
+    net vector), faces are paired by centroid (comparable on the shared source solid), and
+    each pair is compared on net magnitude + direction. An unmatched face is flagged as a
+    missing or spurious load. Without resolved centroids this degrades to one net-aggregate
+    comparison. Magnitude/direction are compared only when both sides carry the data, so an
+    equivalent reformulation (a force modelled as the equivalent pressure) is flagged for
+    review, not gated."""
+    findings: list[Finding] = []
+    cluster_tol = max(1.0, 1e-3 * char_len) if char_len else 1.0
+    match_tol = LOAD_LOC_TOL * char_len if char_len else float("inf")
+
+    # forces: match loaded faces, then compare net magnitude + direction per face ----
+    exp_fc = _cluster_loads(expected, "force", ("magnitude_N", "force_N", "magnitude"), cluster_tol)
+    got_fc = _cluster_loads(got, "force", ("magnitude_N", "force_N", "magnitude"), cluster_tol)
+    if exp_fc and not got_fc:
+        extra = " (a pressure was used instead - verify equivalence)" \
+            if any(ld.get("type") == "pressure" for ld in got) else ""
+        findings.append(Finding(cat, FailureMode.WRONG_LOAD, "major",
+                                f"Label applies {sum(c['mag'] for c in exp_fc):g} N of force but the "
+                                f"candidate applies no force load{extra}.", penalty=30))
+    elif exp_fc:
+        pairs, un_e, un_g = _match_clusters(exp_fc, got_fc, match_tol)
+        for e, g in pairs:
+            _compare_force_pair(e, g, findings, cat)
+        for e in un_e:
+            findings.append(Finding(cat, FailureMode.WRONG_LOAD, "major",
+                                    f"Label applies {e['mag']:g} N of force at {_loc(e['centroid'])} but the "
+                                    "candidate applies none there.", penalty=25))
+        for g in un_g:
+            findings.append(Finding(cat, FailureMode.WRONG_LOAD, "major",
+                                    f"Candidate applies {g['mag']:g} N of force at {_loc(g['centroid'])} not "
+                                    "present in the reference.", penalty=25))
+
+    # pressures: match loaded faces, then compare magnitude per face -----------------
+    exp_pc = _cluster_loads(expected, "pressure", ("magnitude_Pa",), cluster_tol)
+    got_pc = _cluster_loads(got, "pressure", ("magnitude_Pa",), cluster_tol)
+    if exp_pc and not got_pc:
+        extra = " (a force was used instead - verify equivalence)" \
+            if any(ld.get("type") == "force" for ld in got) else ""
+        findings.append(Finding(cat, FailureMode.WRONG_LOAD, "major",
+                                f"Label applies {sum(c['mag'] for c in exp_pc):g} Pa pressure but the "
+                                f"candidate applies none{extra}.", penalty=30))
+    elif exp_pc:
+        pairs, un_e, un_g = _match_clusters(exp_pc, got_pc, match_tol)
+        for e, g in pairs:
+            _mag_finding(g["mag"], e["mag"], "pressure", "Pa", _loc(e["centroid"]), findings, cat)
+        for e in un_e:
+            findings.append(Finding(cat, FailureMode.WRONG_LOAD, "major",
+                                    f"Label applies {e['mag']:g} Pa pressure at {_loc(e['centroid'])} but the "
+                                    "candidate applies none there.", penalty=25))
+        for g in un_g:
+            findings.append(Finding(cat, FailureMode.WRONG_LOAD, "major",
+                                    f"Candidate applies {g['mag']:g} Pa pressure at {_loc(g['centroid'])} not "
+                                    "present in the reference.", penalty=25))
+
+    # self-weight / gravity on-off ---------------------------------------------------
+    if any(ld.get("type") == "self_weight" for ld in expected) and \
+            not any(ld.get("type") == "self_weight" for ld in got):
+        findings.append(Finding(cat, FailureMode.WRONG_LOAD, "minor",
+                                "Label includes self-weight/gravity but the candidate omits it.",
+                                penalty=15))
+    return findings
+
+
+# --------------------------------------------------------------------------- #
+# A. Problem setup correctness                                                #
+# --------------------------------------------------------------------------- #
+def validate_problem_setup(case: CaseDefinition, sub: Submission) -> tuple[float, list[Finding]]:
+    findings: list[Finding] = []
+    cat = "problem_setup"
+
+    # analysis type ---------------------------------------------------------
+    want = _norm_analysis(case.analysis_type)
+    got = _norm_analysis(sub.analysis_type)
+    if not sub.analysis_type:
+        findings.append(Finding(cat, FailureMode.WRONG_ANALYSIS_TYPE, "minor",
+                                "Analysis type not stated.", penalty=8))
+    elif got != want:
+        findings.append(Finding(cat, FailureMode.WRONG_ANALYSIS_TYPE, "critical",
+                                f"Analysis type '{sub.analysis_type}' does not match required "
+                                f"'{case.analysis_type}'.",
+                                evidence=f"got={got} want={want}", penalty=80))
+
+    # units -----------------------------------------------------------------
+    if not sub.units:
+        findings.append(Finding(cat, FailureMode.UNIT_INCONSISTENCY, "minor",
+                                "Units not declared.", penalty=6))
+    else:
+        consistent = metrics.stress_unit_consistent(sub.units)
+        if consistent is False:
+            findings.append(Finding(cat, FailureMode.UNIT_INCONSISTENCY, "major",
+                                    "Declared units are dimensionally inconsistent "
+                                    f"(force={sub.units.get('force')}, length={sub.units.get('length')}, "
+                                    f"stress={sub.units.get('stress')}).", penalty=30))
+
+    # material (expected vs actual) ----------------------------------------
+    exp_E = _num(case.material, "E_MPa", "youngs_modulus_MPa")
+    got_E = _num(sub.material, "E_MPa", "youngs_modulus_MPa")
+    if exp_E and got_E:
+        err = metrics.relative_error(got_E, exp_E)
+        if err > 0.20:
+            findings.append(Finding(cat, FailureMode.WRONG_MATERIAL, "critical",
+                                    f"Young's modulus {got_E:g} MPa differs from the specified "
+                                    f"{exp_E:g} MPa by {err*100:.0f}% - wrong material.", penalty=80))
+    elif exp_E and not got_E:
+        findings.append(Finding(cat, "MATERIAL_NOT_STATED", "minor",
+                                "Young's modulus not reported.", penalty=8))
+
+    # boundary conditions ---------------------------------------------------
+    full, partial = _has_restraint(sub.boundary_conditions)
+    case_full, _ = _has_restraint(case.expected_bcs)
+    # transient/explicit dynamics (e.g. a drop test) can be in free flight with
+    # no classic restraint - rigid-body motion is physical there - so it is not
+    # in the set that requires a fixed support.
+    needs_restraint = want in ("static", "buckling", "thermal_mechanical",
+                               "nonlinear_material", "large_deformation", "contact")
+    expects_bc = len(case.expected_bcs) > 0
+    if needs_restraint and expects_bc:
+        if case_full and not full:
+            # the case calls for a real restraint and the submission lacks one
+            if partial:
+                findings.append(Finding(cat, FailureMode.MISSING_BOUNDARY_CONDITION, "major",
+                                        "Only partial/symmetry restraints found where a full restraint "
+                                        "is required; rigid-body modes may not be removed.", penalty=30))
+            else:
+                findings.append(Finding(cat, FailureMode.MISSING_BOUNDARY_CONDITION, "critical",
+                                        "No restraint/fixed boundary condition - the model is "
+                                        "under-constrained (rigid-body motion).", penalty=80))
+        elif (not case_full) and not (full or partial):
+            # symmetry-reducible case, but the submission has no restraint at all
+            findings.append(Finding(cat, FailureMode.MISSING_BOUNDARY_CONDITION, "critical",
+                                    "No restraint at all - even a symmetry model needs its symmetry "
+                                    "planes constrained to remove rigid-body motion.", penalty=80))
+        elif len(sub.boundary_conditions) < len(case.expected_bcs):
+            findings.append(Finding(cat, "BC_COUNT_LOW", "minor",
+                                    f"Fewer boundary conditions ({len(sub.boundary_conditions)}) than "
+                                    f"expected ({len(case.expected_bcs)}).", penalty=10))
+    elif expects_bc and len(sub.boundary_conditions) < len(case.expected_bcs):
+        findings.append(Finding(cat, "BC_COUNT_LOW", "minor",
+                                f"Fewer boundary conditions ({len(sub.boundary_conditions)}) than "
+                                f"expected ({len(case.expected_bcs)}).", penalty=10))
+
+    # loads -----------------------------------------------------------------
+    expects_load = len(case.expected_loads) > 0
+    if expects_load and not sub.loads and want not in ("modal",):
+        findings.append(Finding(cat, FailureMode.MISSING_LOAD, "major",
+                                "No loads applied although the case requires loading.", penalty=30))
+    elif expects_load and sub.loads:
+        # A load is present; verify that it reproduces the reference loading.
+        # (magnitude, direction, location), not just that something was applied.
+        findings.extend(_compare_loads(case.expected_loads, sub.loads, cat,
+                                       _num(case.geometry, "characteristic_length_mm")))
+
+    return _score_from(findings), findings
+
+
+# --------------------------------------------------------------------------- #
+# B. Mesh quality and convergence                                             #
+# --------------------------------------------------------------------------- #
+def evaluate_mesh(case: CaseDefinition, sub: Submission) -> tuple[float, list[Finding], dict[str, Any]]:
+    findings: list[Finding] = []
+    cat = "mesh_quality"
+    mesh = sub.mesh or {}
+
+    if not mesh:
+        findings.append(Finding(cat, FailureMode.UNJUSTIFIED_MESH, "major",
+                                "No mesh information provided - mesh quality cannot be assessed.",
+                                penalty=40))
+        return _score_from(findings), findings, {"n_grids": 0}
+
+    quality = mesh.get("quality", {}) or {}
+
+    # inverted elements (negative Jacobian) - fatal
+    min_jac = quality.get("min_jacobian")
+    if min_jac is not None and min_jac <= 0:
+        findings.append(Finding(cat, FailureMode.INVERTED_ELEMENTS, "critical",
+                                f"Negative/zero minimum Jacobian ({min_jac:g}) indicates inverted "
+                                "elements; the discretisation is invalid.", penalty=85))
+
+    q_score, q_notes = metrics.mesh_quality_score(quality)
+    if q_score < 100:
+        sev = "major" if q_score < 60 else "minor"
+        findings.append(Finding(cat, FailureMode.POOR_MESH_QUALITY, sev,
+                                "Element-quality metrics out of band: " + "; ".join(q_notes)
+                                if q_notes else "Element-quality metrics out of band.",
+                                penalty=min(40.0, 100.0 - q_score)))
+
+    # mesh density
+    nel = mesh.get("num_elements")
+    min_el = case.mesh_expectations.get("min_elements")
+    if nel is not None and min_el and nel < min_el:
+        findings.append(Finding(cat, "UNDER_RESOLVED", "major",
+                                f"Only {nel} elements; case expects at least ~{min_el} for a "
+                                "resolved field.", penalty=22))
+
+    # convergence study
+    study = mesh.get("convergence_study", []) or []
+    conv = metrics.convergence_from_study(study)
+    expect_conv = case.mesh_expectations.get("expect_convergence", True) and \
+        _norm_analysis(case.analysis_type) in ("static", "thermal", "thermal_mechanical",
+                                               "nonlinear_material", "large_deformation", "contact")
+    singular = bool(case.mesh_expectations.get("singular_features"))
+
+    if expect_conv:
+        if conv["n_grids"] < 2:
+            findings.append(Finding(cat, FailureMode.NO_CONVERGENCE_STUDY, "major",
+                                    "No mesh-convergence study (need >=2-3 refinements to show "
+                                    "the result is mesh-independent).", penalty=28))
+        elif not conv["converged"]:
+            if singular and conv.get("diverging"):
+                findings.append(Finding(cat, "SINGULARITY_PRESENT", "info",
+                                        "Peak quantity diverges with refinement, consistent with a "
+                                        "known stress singularity at a sharp feature.", penalty=0))
+            else:
+                lrc = conv.get("last_rel_change")
+                findings.append(Finding(cat, "MESH_NOT_CONVERGED", "major",
+                                        f"Mesh not converged (last successive change "
+                                        f"{(lrc or 0)*100:.1f}% > 3%).", penalty=25))
+        else:
+            gci = conv.get("gci_fine")
+            if gci is not None and gci > 5.0:
+                findings.append(Finding(cat, "HIGH_GCI", "minor",
+                                        f"Grid Convergence Index {gci:.1f}% > 5% - discretisation "
+                                        "uncertainty is high.", penalty=8))
+
+    # local refinement at stress concentrations
+    refine_at = case.mesh_expectations.get("refine_at")
+    if refine_at and not mesh.get("local_refinement"):
+        findings.append(Finding(cat, "NO_LOCAL_REFINEMENT", "minor",
+                                f"No local refinement reported near {', '.join(refine_at)} "
+                                "where stress gradients are steep.", penalty=10))
+
+    return _score_from(findings), findings, conv
+
+
+# --------------------------------------------------------------------------- #
+# C. Numerical reliability                                                    #
+# --------------------------------------------------------------------------- #
+def evaluate_numerical(case: CaseDefinition, sub: Submission,
+                       conv: dict[str, Any]) -> tuple[float, list[Finding]]:
+    findings: list[Finding] = []
+    cat = "numerical_reliability"
+    solver = sub.solver or {}
+    want = _norm_analysis(case.analysis_type)
+
+    # solver convergence
+    converged = solver.get("converged")
+    if converged is False:
+        findings.append(Finding(cat, FailureMode.SOLVER_NOT_CONVERGED, "critical",
+                                "Solver reported non-convergence; results are unreliable.",
+                                penalty=80))
+    elif converged is None and not solver:
+        findings.append(Finding(cat, "NO_SOLVER_EVIDENCE", "minor",
+                                "No solver convergence/residual evidence provided.", penalty=10))
+
+    # residual
+    resid = solver.get("residual")
+    if isinstance(resid, (int, float)) and resid > 1e-3:
+        sev = "major" if resid > 1e-1 else "minor"
+        findings.append(Finding(cat, "HIGH_RESIDUAL", sev,
+                                f"Solver residual {resid:g} is large.", penalty=20 if sev == "major" else 8))
+
+    # reaction-force equilibrium (static-type analyses with a known applied load)
+    if want in ("static", "nonlinear_material", "large_deformation", "contact"):
+        applied = _magnitude(solver.get("applied_load_N"))
+        reaction = _magnitude(solver.get("reaction_force_N"))
+        if applied and reaction is not None and applied > 0:
+            imb = abs(reaction - applied) / applied
+            if imb > 0.25:
+                findings.append(Finding(cat, FailureMode.REACTION_IMBALANCE, "critical",
+                                        f"Reaction force {reaction:g} N does not balance the applied "
+                                        f"load {applied:g} N ({imb*100:.0f}% imbalance) - equilibrium "
+                                        "is violated.", penalty=80))
+            elif imb > 0.05:
+                findings.append(Finding(cat, FailureMode.REACTION_IMBALANCE, "major",
+                                        f"Reaction/applied imbalance {imb*100:.1f}% exceeds 5%.",
+                                        penalty=30))
+        elif sub.loads and not (
+            solver.get("replay_accepted") or solver.get("replay_verified")
+        ):
+            findings.append(Finding(cat, "NO_REACTION_CHECK", "minor",
+                                    "Trusted applied-load resultant and reaction-force balance are "
+                                    "not both reported (cannot confirm equilibrium).",
+                                    penalty=10))
+
+    # energy balance / artificial (hourglass) energy
+    energy = solver.get("energy", {}) or {}
+    internal = _num(energy, "internal", "ALLIE", "strain")
+    artificial = _num(energy, "artificial", "ALLAE", "hourglass")
+    if internal and artificial is not None and internal > 0:
+        ratio = artificial / internal
+        if ratio > 0.5:
+            findings.append(Finding(cat, FailureMode.ENERGY_IMBALANCE, "critical",
+                                    f"Artificial/hourglass energy is {ratio*100:.0f}% of internal "
+                                    "energy - the solution is dominated by numerical artefacts.",
+                                    penalty=80))
+        elif ratio > 0.10:
+            findings.append(Finding(cat, FailureMode.ENERGY_IMBALANCE, "major",
+                                    f"Artificial energy {ratio*100:.0f}% of internal energy (>10%).",
+                                    penalty=28))
+        elif ratio > 0.05:
+            findings.append(Finding(cat, FailureMode.ENERGY_IMBALANCE, "minor",
+                                    f"Artificial energy {ratio*100:.1f}% of internal energy (>5%).",
+                                    penalty=8))
+
+    # hallucinated convergence: claims mesh-independence with no/contradictory study
+    claim = bool(sub.report.get("convergence_claim")) if sub.report else False
+    if claim:
+        if conv.get("n_grids", 0) < 2:
+            findings.append(Finding(cat, FailureMode.HALLUCINATED_CONVERGENCE, "critical",
+                                    "Report claims a mesh-converged result but provides no "
+                                    "convergence study to support it.", penalty=80))
+        elif not conv.get("converged") and not case.mesh_expectations.get("singular_features"):
+            findings.append(Finding(cat, FailureMode.HALLUCINATED_CONVERGENCE, "critical",
+                                    "Report claims convergence but the supplied study has not "
+                                    "converged.", penalty=80))
+
+    # singularity misinterpreted: claims a finite converged peak at a singular feature
+    if case.mesh_expectations.get("singular_features") and conv.get("diverging"):
+        peak = _num(sub.results, "max_von_mises_MPa", "max_stress_MPa")
+        if peak is not None and claim:
+            findings.append(Finding(cat, FailureMode.SINGULARITY_MISINTERPRETED, "critical",
+                                    "A finite converged peak stress is claimed at a feature that is "
+                                    "a stress singularity (stress diverges with refinement).",
+                                    penalty=80))
+
+    # nonlinear / transient step adequacy
+    if want in ("nonlinear_material", "large_deformation", "transient"):
+        inc_done = solver.get("increments_completed")
+        inc_req = solver.get("increments_requested")
+        if solver.get("diverged_increments") or (
+                isinstance(inc_done, (int, float)) and isinstance(inc_req, (int, float))
+                and inc_done < inc_req):
+            findings.append(Finding(cat, "INCOMPLETE_STEPPING", "major",
+                                    "Load/time stepping did not complete - step size likely "
+                                    "inadequate.", penalty=28))
+
+    return _score_from(findings), findings
+
+
+# --------------------------------------------------------------------------- #
+# D. Physical validity                                                        #
+# --------------------------------------------------------------------------- #
+def evaluate_physical(case: CaseDefinition, sub: Submission) -> tuple[float, list[Finding]]:
+    findings: list[Finding] = []
+    cat = "physical_validity"
+    res = sub.results or {}
+    want = _norm_analysis(case.analysis_type)
+
+    if not res:
+        findings.append(Finding(cat, FailureMode.MISSING_RESULTS, "critical",
+                                "No result quantities reported.", penalty=85))
+        return _score_from(findings), findings
+
+    # von Mises non-negativity / finiteness
+    vm = _num(res, "max_von_mises_MPa", "max_stress_MPa")
+    if vm is not None:
+        if not math.isfinite(vm) or vm < 0:
+            findings.append(Finding(cat, FailureMode.PHYSICALLY_IMPOSSIBLE, "critical",
+                                    f"von Mises stress {vm} is negative or non-finite - impossible.",
+                                    penalty=85))
+        elif vm > 1.0e7:  # > 10 TPa: not a real material stress
+            findings.append(Finding(cat, FailureMode.PHYSICALLY_IMPOSSIBLE, "critical",
+                                    f"von Mises stress {vm:g} MPa is physically impossible.",
+                                    penalty=85))
+
+    # displacement plausibility
+    disp = _num(res, "max_displacement_mm", "max_disp_mm")
+    char = _num(case.geometry, "characteristic_length_mm", "length_mm", "L_mm")
+    if disp is not None and char:
+        if not math.isfinite(disp):
+            findings.append(Finding(cat, FailureMode.PHYSICALLY_IMPOSSIBLE, "critical",
+                                    "Displacement is non-finite.", penalty=85))
+        else:
+            ratio = abs(disp) / char
+            if ratio > 1.0:
+                findings.append(Finding(cat, FailureMode.PHYSICALLY_IMPOSSIBLE, "critical",
+                                        f"Max displacement {disp:g} mm exceeds the characteristic "
+                                        f"size {char:g} mm (ratio {ratio:.1f}) - impossible for this "
+                                        "model.", penalty=85))
+            elif ratio > 0.2 and want == "static":
+                findings.append(Finding(cat, "LARGE_DEFLECTION", "major",
+                                        f"Displacement is {ratio*100:.0f}% of the characteristic size; "
+                                        "small-deflection linear static theory is invalid here.",
+                                        penalty=28))
+    if disp is not None and disp == 0 and sub.loads and want in ("static",):
+        findings.append(Finding(cat, FailureMode.PHYSICALLY_IMPOSSIBLE, "major",
+                                "Zero displacement under a non-zero load is implausible.", penalty=30))
+
+    # material admissibility
+    E = _num(sub.material, "E_MPa", "youngs_modulus_MPa")
+    nu = _num(sub.material, "nu", "poisson", "PoissonRatio")
+    if E is not None and E <= 0:
+        findings.append(Finding(cat, FailureMode.PHYSICALLY_IMPOSSIBLE, "critical",
+                                "Non-positive Young's modulus.", penalty=85))
+    if nu is not None:
+        if nu <= -1.0 or nu > 0.6:
+            findings.append(Finding(cat, FailureMode.PHYSICALLY_IMPOSSIBLE, "critical",
+                                    f"Poisson's ratio {nu} is outside the admissible range "
+                                    "(-1, 0.5].", penalty=85))
+        elif nu >= 0.5:
+            findings.append(Finding(cat, "NU_INCOMPRESSIBLE", "major",
+                                    f"Poisson's ratio {nu} >= 0.5 (near-incompressible) needs special "
+                                    "elements; standard elements lock.", penalty=28))
+        elif nu < 0:
+            findings.append(Finding(cat, "NU_AUXETIC", "minor",
+                                    f"Negative Poisson's ratio {nu} is rare - confirm it is intended.",
+                                    penalty=6))
+
+    # modal
+    if want == "modal":
+        freqs = res.get("natural_frequencies_Hz")
+        free_free = not case.expected_bcs
+        if not freqs:
+            findings.append(Finding(cat, FailureMode.MISSING_RESULTS, "critical",
+                                    "Modal analysis but no natural frequencies reported.", penalty=85))
+        else:
+            nums = [f for f in freqs if isinstance(f, (int, float))]
+            if any((not math.isfinite(f)) or f < -1e-3 for f in nums):
+                findings.append(Finding(cat, FailureMode.FREQ_NONPHYSICAL, "critical",
+                                        "Negative or non-finite natural frequency.", penalty=85))
+            elif not free_free and nums and min(nums) <= 1e-3:
+                findings.append(Finding(cat, FailureMode.FREQ_NONPHYSICAL, "critical",
+                                        "Near-zero fundamental frequency in a constrained model "
+                                        "indicates an unconstrained rigid-body mode.", penalty=80))
+            if nums and nums != sorted(nums):
+                findings.append(Finding(cat, "FREQ_NOT_ASCENDING", "minor",
+                                        "Natural frequencies are not in ascending order.", penalty=8))
+
+    # buckling
+    if want == "buckling":
+        bf = _num(res, "buckling_factor", "load_factor", "buckling_load_factor")
+        if bf is None:
+            findings.append(Finding(cat, FailureMode.MISSING_RESULTS, "critical",
+                                    "Buckling analysis but no buckling/load factor reported.",
+                                    penalty=85))
+        elif bf <= 0:
+            findings.append(Finding(cat, FailureMode.BUCKLING_NONPHYSICAL, "critical",
+                                    f"Non-positive buckling factor {bf} is non-physical.", penalty=85))
+
+    # thermal bounds
+    if want in ("thermal", "thermal_mechanical"):
+        tmax = _num(res, "max_temperature_C", "Tmax_C")
+        bounds = case.physical_bounds.get("temperature_C")
+        if tmax is not None and bounds and (tmax < bounds.get("min", -1e9) or tmax > bounds.get("max", 1e9)):
+            findings.append(Finding(cat, FailureMode.PHYSICALLY_IMPOSSIBLE, "major",
+                                    f"Peak temperature {tmax} C is outside the plausible range "
+                                    f"{bounds}.", penalty=30))
+
+    # explicit physical-bounds from the case (e.g., expected sign of deflection)
+    sign = case.physical_bounds.get("displacement_sign")
+    got_sign = res.get("displacement_sign")
+    if sign and got_sign and sign != got_sign:
+        findings.append(Finding(cat, "WRONG_DEFLECTION_DIRECTION", "major",
+                                f"Deflection direction '{got_sign}' contradicts the expected "
+                                f"'{sign}' for this loading.", penalty=28))
+
+    return _score_from(findings), findings
+
+
+# --------------------------------------------------------------------------- #
+# G. Agent-specific failure modes (cross-cutting)                             #
+# --------------------------------------------------------------------------- #
+def detect_submission_failures(case: CaseDefinition, sub: Submission) -> list[Finding]:
+    findings: list[Finding] = []
+
+    # 1) trusted solver replay: a saved result object is not proof that the solver ran.
+    replay = (sub.meta or {}).get("solver_replay")
+    if isinstance(replay, dict) and not replay.get("passed"):
+        status = replay.get("status", "failed")
+        failures = replay.get("failures") or []
+        detail = "; ".join(str(failure) for failure in failures[:3])
+        findings.append(Finding(
+            "numerical_reliability",
+            FailureMode.UNVERIFIED_SOLVER_OUTPUT,
+            "critical",
+            f"Stored FEM results failed trusted CalculiX replay verification ({status})"
+            + (f": {detail}" if detail else "."),
+            evidence=str(replay),
+            penalty=80,
+        ))
+
+    # 2) internal consistency: same quantity must agree across text/table/plot/results
+    for name, places in (sub.reported_values or {}).items():
+        if not isinstance(places, dict):
+            continue
+        vals = [v for v in places.values() if isinstance(v, (int, float))]
+        res_val = sub.results.get(name)
+        if isinstance(res_val, (int, float)):
+            vals.append(res_val)
+        disc = metrics.max_pairwise_discrepancy(vals)
+        if disc > 0.20:
+            findings.append(Finding("numerical_reliability", FailureMode.INTERNAL_INCONSISTENCY,
+                                    "critical",
+                                    f"Reported '{name}' disagrees across text/table/plot/results by "
+                                    f"{disc*100:.0f}% - numbers are inconsistent (hallucination "
+                                    "signal).", evidence=str(places), penalty=70))
+        elif disc > 0.05:
+            findings.append(Finding("numerical_reliability", FailureMode.INTERNAL_INCONSISTENCY,
+                                    "major",
+                                    f"Reported '{name}' varies by {disc*100:.1f}% across the "
+                                    "submission.", evidence=str(places), penalty=28))
+
+    # 3) hallucinated solver output: results exist but no solver evidence at all
+    has_results = bool(sub.results) and any(
+        isinstance(v, (int, float)) for v in sub.results.values())
+    has_solver_evidence = bool(sub.solver) and (
+        "converged" in sub.solver or "residual" in sub.solver
+        or "reaction_force_N" in sub.solver or "iterations" in sub.solver)
+    result_file = (sub.artifacts or {}).get("result_file")
+    if has_results and not has_solver_evidence and not result_file:
+        findings.append(Finding("numerical_reliability", FailureMode.HALLUCINATED_SOLVER_OUTPUT,
+                                "critical",
+                                "Result quantities are reported with no solver evidence and no "
+                                "result file - the outputs may be fabricated.", penalty=80))
+
+    # 4) reproducibility: need a way to re-run (input deck or script) AND a result file
+    arts = sub.artifacts or {}
+    replay_accepted = bool(
+        (sub.solver or {}).get("replay_accepted")
+        or (sub.solver or {}).get("replay_verified")
+    )
+    has_setup = bool(arts.get("input_deck") or arts.get("script") or replay_accepted)
+    has_result_file = bool(arts.get("result_file"))
+    if not has_setup and not has_result_file:
+        findings.append(Finding("numerical_reliability", FailureMode.NON_REPRODUCIBLE, "critical",
+                                "No input deck/script and no result file - the analysis is not "
+                                "reproducible or verifiable.", penalty=70))
+    elif not has_setup or not has_result_file:
+        missing = "input deck/script" if not has_setup else "result file"
+        findings.append(Finding("engineering_reporting", "PARTIAL_REPRODUCIBILITY", "major",
+                                f"Missing {missing}; reproducibility is only partial.", penalty=20))
+
+    # 5) copy-paste / case mismatch: report describes a different geometry
+    text = " ".join(str(sub.report.get(k, "")) for k in ("interpretation", "assumptions", "summary")).lower()
+    if isinstance(sub.report.get("assumptions"), list):
+        text += " " + " ".join(str(x) for x in sub.report["assumptions"]).lower()
+    correct = (case.subtype or "").lower().replace("_", " ")
+    case_words = [w for w in SHAPE_WORDS if w in (correct + " " + case.title.lower())]
+    if text:
+        mentioned = [w for w in SHAPE_WORDS if w in text]
+        wrong = [w for w in mentioned if w not in case_words
+                 and not any(cw in w or w in cw for cw in case_words)]
+        # only flag if it names a competing shape and never names the right one
+        if wrong and case_words and not any(cw in text for cw in case_words):
+            findings.append(Finding("engineering_reporting", FailureMode.CASE_MISMATCH, "major",
+                                    f"The write-up describes '{wrong[0]}' but the case is "
+                                    f"'{correct or case.title}' - boilerplate/copy-paste suspected.",
+                                    penalty=30))
+    return findings
+
+
+def validate_geometry_fidelity(case: CaseDefinition, sub: Submission) -> list[Finding]:
+    """Did the submission actually analyse the target geometry?
+
+    Compares the target geometry (e.g. from a STEP file, carried on
+    ``case.geometry``) against the body the submission analysed
+    (``sub.geometry``). Volume is the primary, mesh-independent signal; the
+    bounding-box characteristic length is the fallback. A no-op when either side
+    lacks the data, so this is safe to call on reference-based cases too.
+    """
+    cat = "problem_setup"
+    sv, fv = _num(case.geometry, "volume_mm3"), _num(sub.geometry, "volume_mm3")
+    if sv and fv and sv > 0:
+        err = abs(fv - sv) / sv
+        if err > 0.25:
+            return [Finding(cat, FailureMode.GEOMETRY_MISMATCH, "critical",
+                            f"Analysed body volume {fv:.0f} mm^3 differs from the target geometry "
+                            f"{sv:.0f} mm^3 by {err*100:.0f}% - a different or incomplete part was "
+                            "analysed.", penalty=80)]
+        if err > 0.05:
+            return [Finding(cat, FailureMode.GEOMETRY_MISMATCH, "major",
+                            f"Analysed body volume differs from the target geometry by "
+                            f"{err*100:.1f}%.", penalty=30)]
+        return []
+    sc, fc = _num(case.geometry, "characteristic_length_mm"), _num(sub.geometry, "characteristic_length_mm")
+    if sc and fc and sc > 0:
+        err = abs(fc - sc) / sc
+        if err > 0.25:
+            return [Finding(cat, FailureMode.GEOMETRY_MISMATCH, "critical",
+                            f"Analysed body size differs from the target by {err*100:.0f}% "
+                            "(no volume available to compare).", penalty=80)]
+        if err > 0.05:
+            return [Finding(cat, FailureMode.GEOMETRY_MISMATCH, "major",
+                            f"Analysed body size differs from the target by {err*100:.1f}%.",
+                            penalty=30)]
+    return []
+
+
+def evaluate_mesh_budget(case: CaseDefinition, sub: Submission) -> tuple[float | None, list[Finding]]:
+    """Mesh-efficiency category: candidate element count vs a baseline.
+
+    The baseline (for example, the reference element count) is carried on
+    ``case.mesh_expectations["baseline_num_elements"]``; the ceiling ratio is
+    ``budget_zero_ratio`` (default 1.3). Returns ``(score_0_100, findings)`` or
+    ``(None, [])`` when no baseline is available (so the weight is redistributed).
+    Findings carry penalty 0 because the *score* already encodes the deduction.
+    """
+    baseline = case.mesh_expectations.get("baseline_num_elements")
+    if not baseline:
+        return None, []
+    cand = (sub.mesh or {}).get("num_elements")
+    if not cand:
+        return None, []
+    zero_at = case.mesh_expectations.get("budget_zero_ratio", MESH_BUDGET_ZERO_RATIO)
+    floor_ratio = case.mesh_expectations.get("budget_floor_ratio", MESH_BUDGET_FLOOR_RATIO)
+    ratio = cand / baseline
+    findings: list[Finding] = []
+    # Lower floor: a mesh far below the baseline is too coarse to have resolved the
+    # field. Deny the efficiency credit so a real solve cannot be paired with a
+    # A trivial mesh must not receive the mesh-budget efficiency share; going
+    # coarser is only "efficient" down to a point, below which it is under-resolved.
+    if cand < floor_ratio * baseline:
+        findings.append(Finding("mesh_budget", "MESH_BUDGET_UNDERRESOLVED", "major",
+                                f"Candidate mesh has {cand} elements = {ratio*100:.2f}% of the reference "
+                                f"baseline ({baseline}); below the {floor_ratio*100:.0f}% floor a mesh "
+                                "is too coarse to have resolved the field, so the mesh-budget sub-score "
+                                "is 0 (a degenerate mesh cannot receive efficiency credit for a real "
+                                "solve).", penalty=0))
+        return 0.0, findings
+    score = metrics.mesh_budget_score(cand, baseline, zero_at)
+    if score <= 0.0:
+        findings.append(Finding("mesh_budget", "MESH_BUDGET_EXCEEDED", "major",
+                                f"Candidate mesh has {cand} elements = {ratio*100:.0f}% of the reference "
+                                f"baseline ({baseline}); at/over {zero_at*100:.0f}% the mesh-budget "
+                                "sub-score is 0.", penalty=0))
+    elif score < 100.0:
+        findings.append(Finding("mesh_budget", "MESH_BUDGET_OVER", "minor",
+                                f"Candidate mesh has {cand} elements = {ratio*100:.0f}% of the reference "
+                                f"baseline ({baseline}); over budget -> mesh-budget sub-score "
+                                f"{score:.0f}/100.", penalty=0))
+    return score, findings
+
+
+def reproducibility_status(sub: Submission) -> str:
+    arts = sub.artifacts or {}
+    replay_accepted = bool(
+        (sub.solver or {}).get("replay_accepted")
+        or (sub.solver or {}).get("replay_verified")
+    )
+    has_setup = bool(arts.get("input_deck") or arts.get("script") or replay_accepted)
+    has_result_file = bool(arts.get("result_file"))
+    if has_setup and has_result_file:
+        return "reproducible"
+    if has_setup or has_result_file:
+        return "partial"
+    return "non_reproducible"

--- a/tests/e2e/generate_fem_fixture.py
+++ b/tests/e2e/generate_fem_fixture.py
@@ -1,0 +1,37 @@
+"""Generate a small solved cantilever fixture with FreeCAD's public FEM example."""
+
+import os
+import sys
+
+import Part
+from femexamples.ccx_cantilever_faceload import setup
+from femtools.ccxtools import FemToolsCcx
+
+
+def main():
+    step_path = next(arg for arg in sys.argv if arg.lower().endswith(".step"))
+    fcstd_path = next(arg for arg in sys.argv if arg.lower().endswith(".fcstd"))
+    working_dir = os.path.dirname(os.path.abspath(fcstd_path))
+
+    doc = setup(test_mode=True)
+    Part.export([doc.Box], step_path)
+    solver = doc.CalculiXCcxTools
+    solver.WorkingDir = working_dir
+    fem = FemToolsCcx(doc.Analysis, solver)
+    fem.update_objects()
+    fem.setup_working_dir(working_dir, create=True)
+    fem.setup_ccx()
+    prerequisites = fem.check_prerequisites()
+    if prerequisites:
+        raise RuntimeError(f"CalculiX prerequisites failed: {prerequisites}")
+    fem.purge_results()
+    fem.write_inp_file()
+    return_code = fem.ccx_run()
+    if return_code not in (None, 0):
+        raise RuntimeError(f"CalculiX failed with exit code {return_code}")
+    fem.load_results()
+    doc.recompute()
+    doc.saveAs(fcstd_path)
+
+
+main()

--- a/tests/e2e/test_fem_end_to_end.py
+++ b/tests/e2e/test_fem_end_to_end.py
@@ -1,0 +1,38 @@
+"""Opt-in end-to-end FEM replay using a generated, non-sensitive fixture."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from freecad_validator._freecad_loader import resolve_freecad_command
+from freecad_validator.fem import FEMValidator
+
+
+@pytest.mark.needs_freecad
+@pytest.mark.needs_calculix
+def test_generated_cantilever_replays_with_calculix(tmp_path):
+    freecad_cmd = resolve_freecad_command()
+    step_path = tmp_path / "cantilever.step"
+    reference_path = tmp_path / "reference.FCStd"
+    candidate_path = tmp_path / "candidate.FCStd"
+    generator = Path(__file__).with_name("generate_fem_fixture.py")
+
+    subprocess.run(
+        [freecad_cmd, str(generator), str(step_path), str(reference_path)],
+        check=True,
+        timeout=180,
+    )
+    shutil.copy2(reference_path, candidate_path)
+
+    report = FEMValidator(freecad_cmd=freecad_cmd, timeout_seconds=180).validate(
+        step_path=str(step_path),
+        reference_fcstd=str(reference_path),
+        candidate_fcstd=str(candidate_path),
+    )
+
+    assert report.overall_score >= 85.0
+    assert report.gates_triggered == []
+    assert report.runtime_provenance["freecad"].startswith("1.1")
+    assert report.runtime_provenance["calculix"]

--- a/tests/integration/check_fem_adapter_import.py
+++ b/tests/integration/check_fem_adapter_import.py
@@ -1,0 +1,44 @@
+"""Exercise an installed FCStd adapter without importing its host package."""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def main():
+    adapter = Path(sys.argv[1]).resolve()
+    if not adapter.is_file():
+        raise FileNotFoundError(adapter)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        stubs = Path(temp_dir)
+        (stubs / "FreeCAD.py").write_text(
+            "class Units:\n    pass\n",
+            encoding="utf-8",
+        )
+        femtools = stubs / "femtools"
+        femtools.mkdir()
+        (femtools / "ccxtools.py").write_text(
+            "class FemToolsCcx:\n    pass\n",
+            encoding="utf-8",
+        )
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(stubs)
+        completed = subprocess.run(
+            [sys.executable, str(adapter), "import-check"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=10,
+        )
+    if completed.returncode != 0:
+        raise RuntimeError(completed.stderr)
+    if "pure replay module loaded" not in completed.stdout:
+        raise RuntimeError(f"unexpected adapter output: {completed.stdout!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_fem_api.py
+++ b/tests/unit/test_fem_api.py
@@ -1,0 +1,73 @@
+"""FreeCAD-free tests for the public FEM API and CLI wiring."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from freecad_validator.cli.main import main
+from freecad_validator.fem import FEMScoringReport, FEMValidator, ScoringReport
+
+
+def _report() -> ScoringReport:
+    return ScoringReport(
+        case_id="example",
+        overall_score=91.0,
+        grade="excellent",
+        confidence=1.0,
+        reproducibility_status="reproducible",
+    )
+
+
+def test_fem_scoring_report_is_the_public_report_type() -> None:
+    assert FEMScoringReport is ScoringReport
+
+
+def test_validator_rejects_invalid_configuration() -> None:
+    with pytest.raises(ValueError, match="displacement_tolerance must be positive"):
+        FEMValidator(displacement_tolerance=0.0)
+    with pytest.raises(ValueError, match="mesh_budget_zero_ratio"):
+        FEMValidator(mesh_budget_zero_ratio=1.0)
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        FEMValidator(timeout_seconds=0.0)
+
+
+def test_validator_forwards_configuration() -> None:
+    validator = FEMValidator(
+        freecad_cmd="/fake/freecadcmd",
+        extract_dir="/tmp/extract",
+        require_boolean=True,
+        timeout_seconds=45.0,
+    )
+    with patch("freecad_validator.fem.validator.score_step_fcstd", return_value=_report()) as score:
+        report = validator.validate(
+            step_path="source.step",
+            reference_fcstd="reference.FCStd",
+            candidate_fcstd="candidate.FCStd",
+        )
+
+    assert report.overall_score == 91.0
+    assert score.call_args.kwargs["require_boolean"] is True
+    assert score.call_args.kwargs["freecad_cmd"] == "/fake/freecadcmd"
+    assert score.call_args.kwargs["timeout_seconds"] == 45.0
+
+
+def test_fem_score_cli_emits_json(capsys) -> None:
+    with patch("freecad_validator.cli.main.FEMValidator.validate", return_value=_report()):
+        code = main([
+            "fem-score",
+            "source.step",
+            "reference.FCStd",
+            "candidate.FCStd",
+            "--json",
+            "--require-boolean",
+            "--timeout",
+            "45",
+        ])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["overall_score"] == 91.0
+    assert payload["grade"] == "excellent"

--- a/tests/unit/test_fem_metrics.py
+++ b/tests/unit/test_fem_metrics.py
@@ -1,0 +1,78 @@
+"""Unit tests for the numeric helpers (scorer/metrics.py)."""
+
+
+from freecad_validator.fem import metrics
+
+
+def test_relative_error():
+    assert metrics.relative_error(110, 100) == 0.1
+    assert metrics.relative_error(90, 100) == 0.1
+    assert metrics.relative_error(5, 0) == 5.0  # safe ref==0 fallback
+
+
+def test_tolerance_band_score_boundaries():
+    assert metrics.tolerance_band_score(0.05, 0.10) == 100.0      # inside tol
+    assert metrics.tolerance_band_score(0.10, 0.10) == 100.0      # at tol
+    assert metrics.tolerance_band_score(0.40, 0.10, fade=4) == 0.0  # at fade*tol
+    mid = metrics.tolerance_band_score(0.25, 0.10, fade=4)
+    assert 0.0 < mid < 100.0
+
+
+def test_within_tolerance():
+    ok, err = metrics.within_tolerance(104, 100, 0.05)
+    assert ok and abs(err - 0.04) < 1e-9
+    ok, err = metrics.within_tolerance(120, 100, 0.05)
+    assert not ok
+
+
+def test_mesh_quality_good_vs_bad():
+    good, _ = metrics.mesh_quality_score(
+        {"min_jacobian": 0.8, "max_aspect_ratio": 2.5, "max_skewness": 0.4})
+    bad, notes = metrics.mesh_quality_score(
+        {"min_jacobian": 0.2, "max_aspect_ratio": 25.0, "max_skewness": 0.98,
+         "pct_elements_below_jac": 8.0})
+    assert good > 95
+    assert bad < 40
+    assert notes  # human-readable issues reported
+
+
+def test_convergence_converged():
+    study = [{"n_elements": 4000, "value": 0.96},
+             {"n_elements": 32000, "value": 0.99},
+             {"n_elements": 256000, "value": 1.00}]
+    out = metrics.convergence_from_study(study)
+    assert out["converged"] is True
+    assert out["n_grids"] == 3
+    assert out["gci_fine"] is not None
+    assert out["apparent_order"] is not None
+
+
+def test_convergence_diverging_singularity():
+    study = [{"n_elements": 4000, "value": 100.0},
+             {"n_elements": 32000, "value": 160.0},
+             {"n_elements": 256000, "value": 250.0}]
+    out = metrics.convergence_from_study(study)
+    assert out["converged"] is False
+    assert out["diverging"] is True
+
+
+def test_values_agree_and_discrepancy():
+    assert metrics.values_agree([100.0, 100.5, 99.8]) is True
+    assert metrics.values_agree([100.0, 135.0]) is False
+    assert metrics.max_pairwise_discrepancy([100.0, 135.0]) > 0.2
+
+
+def test_stress_unit_consistency():
+    assert metrics.stress_unit_consistent(
+        {"force": "N", "length": "mm", "stress": "MPa"}) is True
+    assert metrics.stress_unit_consistent(
+        {"force": "N", "length": "mm", "stress": "Pa"}) is False
+    assert metrics.stress_unit_consistent({"force": "N"}) is None
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print("ok:", fn.__name__)
+    print(f"{len(fns)} metric tests passed")

--- a/tests/unit/test_fem_replay_compare.py
+++ b/tests/unit/test_fem_replay_compare.py
@@ -1,0 +1,104 @@
+"""Regression tests for trusted FEM replay field comparison."""
+
+import math
+
+from freecad_validator.fem.replay_compare import compare_result_snapshots, select_scored_results
+
+
+def _snapshot(scale=1.0):
+    return {
+        "node_numbers": [1, 2, 3, 4],
+        "fields": {
+            "DisplacementLengths": [value * scale for value in (0.0, 1.0, 2.0, 4.0)],
+            "DisplacementVectors": [
+                (0.0, 0.0, value * scale) for value in (0.0, 1.0, 2.0, 4.0)
+            ],
+            "vonMises": [value * scale for value in (0.0, 10.0, 20.0, 40.0)],
+            "MaxShear": [value * scale for value in (0.0, 5.0, 10.0, 20.0)],
+        },
+    }
+
+
+def test_identical_replayed_fields_pass():
+    result = compare_result_snapshots(_snapshot(), _snapshot(), "static")
+    assert result["passed"] is True
+    assert result["status"] == "verified"
+
+
+def test_one_percent_replay_difference_passes():
+    result = compare_result_snapshots(_snapshot(1.01), _snapshot(), "static")
+    assert result["passed"] is True
+
+
+def test_three_percent_replay_difference_is_accepted_with_warning():
+    result = compare_result_snapshots(_snapshot(1.03), _snapshot(), "static")
+    assert result["passed"] is True
+    assert result["status"] == "accepted_mismatch"
+    assert any("exceeds 2%" in warning for warning in result["warnings"])
+
+
+def test_accepted_mismatch_scores_stored_results():
+    scored, source = select_scored_results(
+        {"max_displacement_mm": 1.1},
+        {"max_displacement_mm": 1.0},
+        {"status": "accepted_mismatch"},
+    )
+    assert scored == {"max_displacement_mm": 1.1}
+    assert source == "stored"
+
+
+def test_verified_replay_scores_replayed_results():
+    scored, source = select_scored_results(
+        {"max_displacement_mm": 1.01},
+        {"max_displacement_mm": 1.0},
+        {"status": "verified"},
+    )
+    assert scored == {"max_displacement_mm": 1.0}
+    assert source == "replayed"
+
+
+def test_more_than_ten_percent_rms_difference_fails():
+    result = compare_result_snapshots(_snapshot(1.11), _snapshot(), "static")
+    assert result["passed"] is False
+    assert result["status"] == "mismatch"
+    assert any("exceeds 10%" in failure for failure in result["failures"])
+
+
+def test_more_than_ten_percent_peak_difference_fails():
+    stored = _snapshot()
+    stored["fields"]["vonMises"][-1] *= 1.11
+    result = compare_result_snapshots(stored, _snapshot(), "static")
+    assert result["passed"] is False
+    assert any("peak error" in failure and "exceeds 10%" in failure
+               for failure in result["failures"])
+
+
+def test_matching_peak_with_fabricated_constant_field_fails():
+    fabricated = _snapshot()
+    fabricated["fields"]["DisplacementLengths"] = [4.0, 4.0, 4.0, 4.0]
+    result = compare_result_snapshots(fabricated, _snapshot(), "static")
+
+    assert result["passed"] is False
+    comparison = result["field_comparisons"]["DisplacementLengths"]
+    assert comparison["peak_relative_error"] == 0.0
+    assert comparison["normalized_rms_error"] > 0.10
+
+
+def test_missing_required_static_field_fails():
+    stored = _snapshot()
+    del stored["fields"]["DisplacementVectors"]
+    result = compare_result_snapshots(stored, _snapshot(), "static")
+    assert result["passed"] is False
+    assert any("missing required field DisplacementVectors" in failure
+               for failure in result["failures"])
+
+
+def test_changed_node_order_and_nonfinite_field_fail():
+    stored = _snapshot()
+    stored["node_numbers"] = [4, 3, 2, 1]
+    stored["fields"]["vonMises"][2] = math.nan
+    result = compare_result_snapshots(stored, _snapshot(), "static")
+
+    assert result["passed"] is False
+    assert any("node ordering" in failure for failure in result["failures"])
+    assert result["field_comparisons"]["vonMises"]["finite"] is False

--- a/tests/unit/test_fem_scorer.py
+++ b/tests/unit/test_fem_scorer.py
@@ -1,0 +1,162 @@
+"""Behavioral tests for :mod:`freecad_validator.fem.scorer`."""
+
+
+from freecad_validator.fem import CaseDefinition, FailureMode, Submission, score_result
+
+
+def _case():
+    return CaseDefinition(
+        case_id="T01", title="Cantilever tip load", subtype="cantilever", analysis_type="static",
+        units_expected={"length": "mm", "force": "N", "stress": "MPa"},
+        geometry={"characteristic_length_mm": 1000.0},
+        material={"E_MPa": 210000.0, "nu": 0.30, "yield_MPa": 250.0},
+        expected_bcs=[{"type": "fixed"}],
+        expected_loads=[{"type": "force", "magnitude_N": 1000.0}],
+        reference={"method": "analytical", "source": "Roark",
+                   "quantities": {"max_displacement_mm": {"value": 3.05, "unit": "mm", "tol_rel": 0.10, "critical": True},
+                                  "max_von_mises_MPa": {"value": 48.0, "unit": "MPa", "tol_rel": 0.15}}},
+        mesh_expectations={"expect_convergence": True})
+
+
+def _excellent():
+    return Submission(
+        case_id="T01", analysis_type="static",
+        units={"length": "mm", "force": "N", "stress": "MPa"},
+        material={"E_MPa": 210000.0, "nu": 0.30},
+        boundary_conditions=[{"type": "fixed", "location": "root"}],
+        loads=[{"type": "force", "magnitude_N": 1000.0, "direction": [0, 0, -1]}],
+        mesh={"element_type": "C3D10", "num_elements": 60000, "local_refinement": True,
+              "quality": {"min_jacobian": 0.7, "max_aspect_ratio": 3.0, "max_skewness": 0.45,
+                          "pct_elements_below_jac": 0.0},
+              "convergence_study": [{"n_elements": 4000, "value": 2.95},
+                                    {"n_elements": 32000, "value": 3.02},
+                                    {"n_elements": 256000, "value": 3.05}]},
+        solver={"name": "CalculiX", "converged": True, "residual": 1e-9,
+                "applied_load_N": 1000.0, "reaction_force_N": [0, 0, 1000.2]},
+        results={"max_displacement_mm": 3.05, "max_von_mises_MPa": 48.0, "safety_factor": 5.2},
+        reported_values={"max_displacement_mm": {"text": 3.05, "table": 3.05, "plot": 3.05}},
+        report={"assumptions": ["linear elastic"], "interpretation": "Tip deflects 3.05 mm; peak stress at the root as expected for a cantilever under an end load.",
+                "limitations": ["sharp built-in edge singularity ignored"], "convergence_claim": True,
+                "mesh_justification": "second-order tets refined at the support; <1% change on refinement",
+                "safety_factor_discussion": "SF=5.2 vs yield"},
+        artifacts={"input_deck": "job.inp", "result_file": "job.frd", "script": "run.py"})
+
+
+def test_excellent_scores_high():
+    rep = score_result(_case(), _excellent())
+    assert rep.overall_score >= 90
+    assert rep.grade in ("excellent", "good")
+    assert isinstance(rep.subscores["problem_setup"], float)
+    assert "raw_score" in rep.subscores_details["problem_setup"]
+    assert rep.pass_fail_flags["physically_valid"]
+    assert rep.pass_fail_flags["reproducible"]
+    assert rep.pass_fail_flags["not_hallucinated"]
+    assert not rep.failure_modes_detected
+
+
+def test_physically_impossible_gates_to_zero():
+    sub = _excellent()
+    sub.results["max_displacement_mm"] = 1800.0  # > characteristic length
+    rep = score_result(_case(), sub)
+    assert rep.overall_score == 0
+    assert rep.grade == "invalid"
+    assert any(f["code"] == FailureMode.PHYSICALLY_IMPOSSIBLE for f in rep.failure_modes_detected)
+    assert not rep.pass_fail_flags["physically_valid"]
+    assert rep.gates_triggered
+
+
+def test_negative_von_mises_impossible():
+    sub = _excellent()
+    sub.results["max_von_mises_MPa"] = -10.0
+    rep = score_result(_case(), sub)
+    assert any(f["code"] == FailureMode.PHYSICALLY_IMPOSSIBLE for f in rep.failure_modes_detected)
+
+
+def test_missing_boundary_condition():
+    sub = _excellent()
+    sub.boundary_conditions = []
+    rep = score_result(_case(), sub)
+    assert any(f["code"] == FailureMode.MISSING_BOUNDARY_CONDITION for f in rep.failure_modes_detected)
+    assert not rep.pass_fail_flags["setup_correct"]
+
+
+def test_hallucinated_solver_output():
+    sub = _excellent()
+    sub.solver = {}
+    sub.artifacts = {}
+    rep = score_result(_case(), sub)
+    codes = {f["code"] for f in rep.failure_modes_detected}
+    assert FailureMode.HALLUCINATED_SOLVER_OUTPUT in codes or FailureMode.NON_REPRODUCIBLE in codes
+    assert rep.overall_score == 0
+
+
+def test_hallucinated_convergence():
+    sub = _excellent()
+    sub.mesh["convergence_study"] = []          # no study
+    sub.report["convergence_claim"] = True       # but claims convergence
+    rep = score_result(_case(), sub)
+    assert any(f["code"] == FailureMode.HALLUCINATED_CONVERGENCE for f in rep.failure_modes_detected)
+
+
+def test_internal_inconsistency():
+    sub = _excellent()
+    sub.reported_values = {"max_displacement_mm": {"text": 3.05, "table": 4.5, "plot": 3.05}}
+    rep = score_result(_case(), sub)
+    assert any(f["code"] == FailureMode.INTERNAL_INCONSISTENCY for f in rep.failure_modes_detected)
+
+
+def test_reaction_imbalance():
+    sub = _excellent()
+    sub.solver["reaction_force_N"] = [0, 0, 1400.0]  # 40% off applied 1000
+    rep = score_result(_case(), sub)
+    assert any(f["code"] == FailureMode.REACTION_IMBALANCE for f in rep.failure_modes_detected)
+
+
+def test_accuracy_gross_error():
+    sub = _excellent()
+    sub.results["max_displacement_mm"] = 30.5   # 10x reference
+    rep = score_result(_case(), sub)
+    acc = rep.subscores["accuracy_vs_reference"]
+    assert acc < 50
+
+
+def test_wrong_material_flagged():
+    sub = _excellent()
+    sub.material["E_MPa"] = 70000.0  # aluminium instead of steel
+    rep = score_result(_case(), sub)
+    assert any(f["code"] == FailureMode.WRONG_MATERIAL for f in rep.failure_modes_detected)
+
+
+def test_determinism():
+    case, sub = _case(), _excellent()
+    a = score_result(case, sub).overall_score
+    b = score_result(case, sub).overall_score
+    assert a == b
+
+
+def test_accuracy_weight_redistributed_when_no_reference():
+    case = _case()
+    case.reference = {"method": "none"}  # no quantities, no ranges
+    rep = score_result(case, _excellent())
+    # accuracy weight should be redistributed: its weight shown as 0
+    assert rep.subscores_details["accuracy_vs_reference"]["weight"] == 0.0
+    total_w = sum(rep.subscores_details[c]["weight"] for c in rep.subscores_details)
+    assert abs(total_w - 1.0) < 1e-6
+
+
+def test_polished_but_wrong_cannot_pass():
+    """A perfect write-up cannot rescue a physically impossible result."""
+    sub = _excellent()  # full report
+    sub.results["max_displacement_mm"] = 5000.0
+    rep = score_result(_case(), sub)
+    assert rep.overall_score == 0
+    assert rep.subscores["engineering_reporting"] >= 80  # report still good
+    assert rep.grade == "invalid"
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print("ok:", fn.__name__)
+    print(f"{len(fns)} scorer tests passed")

--- a/tests/unit/test_fem_step_interface.py
+++ b/tests/unit/test_fem_step_interface.py
@@ -1,0 +1,821 @@
+"""Tests for the STEP + reference + candidate FEM validator."""
+
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import Mock, patch
+
+import pytest
+
+from freecad_validator.fem import (
+    FailureMode,
+    RuntimeEnvironmentError,
+    score_step_fcstd,
+    score_trusted_payloads,
+)
+from freecad_validator.fem.step_interface import (
+    FCSTD_ADAPTER,
+    ExtractionError,
+    _extract,
+    _run_adapter,
+)
+
+STEP = {"volume_mm3": 1.0e6, "characteristic_length_mm": 387.0, "bbox_mm": [120, 360, 60]}
+
+
+@pytest.fixture(autouse=True)
+def resolve_fake_freecad_command(monkeypatch):
+    """Keep extraction tests independent of a host FreeCAD installation."""
+    monkeypatch.setattr(
+        "freecad_validator.fem.step_interface.resolve_freecad_command",
+        lambda explicit=None: explicit or "/fake/freecadcmd",
+    )
+    monkeypatch.setattr(
+        "freecad_validator.fem.step_interface._runtime_preflight",
+        lambda *_args, **_kwargs: {
+            "freecad": "1.1.0",
+            "occt": "7.8.1",
+            "python": "3.11.9",
+            "calculix": "2.23",
+        },
+    )
+
+LABEL = dict(
+    analysis_type="static",
+    material={"E_MPa": 200000.0, "nu": 0.3},
+    boundary_conditions=[{"type": "fixed", "location": "Body/Face10"}],
+    loads=[{"type": "force", "magnitude_N": 500.0, "location": "Body/Face14"}],
+    results={"max_displacement_mm": 3.0e-4, "max_von_mises_MPa": 0.35, "max_shear_MPa": 0.19},
+    geometry={"volume_mm3": 1.0e6, "characteristic_length_mm": 387.0},
+    mesh={"num_nodes": 20000, "num_elements": 12000},   # mesh-budget baseline
+)
+
+
+def _cand(**over):
+    base = dict(
+        analysis_type="static",
+        units={"length": "mm", "force": "N", "stress": "MPa"},
+        material={"E_MPa": 200000.0, "nu": 0.3},
+        boundary_conditions=[{"type": "fixed"}],
+        loads=[{"type": "force", "magnitude_N": 500.0}],
+        mesh={"num_nodes": 20000, "num_elements": 12000},
+        solver={"converged": True, "applied_load_N": 500.0, "reaction_force_N": [0, 0, 500.1]},
+        results={"max_displacement_mm": 3.05e-4, "max_von_mises_MPa": 0.37, "max_shear_MPa": 0.196},
+        geometry={"volume_mm3": 1.005e6, "characteristic_length_mm": 387.0},
+        artifacts={"result_file": "c.FCStd", "input_deck": "c.FCStd"},
+    )
+    base.update(over)
+    return base
+
+
+def _topology_geometry(
+    region_volumes,
+    *,
+    num_compsolids=0,
+    shape_types=None,
+):
+    regions = [
+        {
+            "volume_mm3": volume,
+            "surface_area_mm2": 1000.0 / len(region_volumes),
+            "num_faces": 6 + index,
+            "num_edges": 12 + index,
+            "num_shells": 1,
+        }
+        for index, volume in enumerate(region_volumes)
+    ]
+    return {
+        "volume_mm3": sum(region_volumes),
+        "surface_area_mm2": 1000.0,
+        "characteristic_length_mm": 387.0,
+        "bbox_mm": [120.0, 360.0, 60.0],
+        "num_solids": len(regions),
+        "num_compsolids": num_compsolids,
+        "shape_types": shape_types or ["Compound"],
+        "num_faces": sum(region["num_faces"] for region in regions),
+        "num_edges": sum(region["num_edges"] for region in regions),
+        "regions": regions,
+    }
+
+
+def test_candidate_matches_label_scores_high():
+    rep = score_trusted_payloads(STEP, LABEL, _cand())
+    assert rep.overall_score >= 90
+    assert rep.grade == "excellent"
+    crit = next(c for c in rep.numerical_comparisons if c["critical"])
+    assert crit["within_tol"]
+
+
+def test_trusted_replay_without_reaction_evidence_has_full_numerical_score():
+    candidate = _cand(
+        solver={"converged": True, "replay_verified": False, "replay_accepted": True},
+    )
+    rep = score_trusted_payloads(STEP, LABEL, candidate)
+    assert rep.subscores["numerical_reliability"] == 100.0
+    assert not any(
+        finding["code"] == "NO_REACTION_CHECK"
+        for finding in rep.subscores_details["numerical_reliability"]["findings"]
+    )
+
+
+def test_opposing_load_magnitudes_are_not_summed_for_reaction_balance():
+    candidate = _cand(
+        loads=[
+            {"type": "force", "magnitude_N": 500.0, "direction": [1, 0, 0]},
+            {"type": "force", "magnitude_N": 500.0, "direction": [-1, 0, 0]},
+        ],
+        solver={"converged": True, "reaction_force_N": [0, 0, 0]},
+    )
+    rep = score_trusted_payloads(STEP, LABEL, candidate)
+    findings = rep.subscores_details["numerical_reliability"]["findings"]
+    assert not any(finding["code"] == FailureMode.REACTION_IMBALANCE
+                   for finding in findings)
+    assert any(finding["code"] == "NO_REACTION_CHECK" for finding in findings)
+
+
+def test_accuracy_table_present_with_reference():
+    rep = score_trusted_payloads(STEP, LABEL, _cand())
+    assert rep.numerical_comparisons  # Candidate-vs-reference comparisons exist.
+    assert any("reference-based" in e for e in rep.evidence)
+
+
+def test_gross_miss_vs_label_gates_to_zero():
+    rep = score_trusted_payloads(STEP, LABEL, _cand(
+        results={"max_displacement_mm": 6.0e-4, "max_von_mises_MPa": 0.70, "max_shear_MPa": 0.38}))
+    assert rep.overall_score == 0
+    assert rep.grade == "invalid"
+    assert any(f["code"] == FailureMode.ACCURACY_GROSS_ERROR for f in rep.failure_modes_detected)
+    assert rep.gates_triggered
+
+
+def test_omitting_critical_quantity_gates_to_zero():
+    """Omitting the critical quantity must NOT out-score reporting it wrong.
+
+    Regression for the omit-displacement reward hack: a fabricated result that
+    drops max_displacement_mm (stress only) once scored 64.5 because the gross-miss
+    gate skipped a None rel_error. A missing critical quantity now gates to 0, the
+    same as a gross error - so omitting it can never beat getting it wrong.
+    """
+    rep = score_trusted_payloads(STEP, LABEL, _cand(
+        results={"max_von_mises_MPa": 0.35, "max_shear_MPa": 0.19}))  # no displacement
+    assert rep.overall_score == 0
+    assert rep.grade == "invalid"
+    assert any(f["code"] == FailureMode.ACCURACY_GROSS_ERROR for f in rep.failure_modes_detected)
+    assert rep.gates_triggered
+
+
+def test_gross_wrong_load_magnitude_gates_to_zero():
+    """A grossly wrong applied load is a different problem and must gate, even if
+    the reported results happen to sit near the label (compensating-error blind spot)."""
+    rep = score_trusted_payloads(STEP, LABEL, _cand(
+        loads=[{"type": "force", "magnitude_N": 5000.0}]))   # 10x the label's 500 N
+    assert rep.overall_score == 0
+    assert rep.grade == "invalid"
+    assert any(f["code"] == FailureMode.WRONG_LOAD for f in rep.failure_modes_detected)
+    assert rep.gates_triggered
+
+
+def test_mild_load_mismatch_penalized_not_gated():
+    """An 8% load error dents problem_setup but does not gate."""
+    rep = score_trusted_payloads(STEP, LABEL, _cand(
+        loads=[{"type": "force", "magnitude_N": 540.0}]))    # +8% -> major, no gate
+    assert not rep.gates_triggered
+    assert rep.subscores["problem_setup"] < 100
+    assert any(f["code"] == FailureMode.WRONG_LOAD for f in rep.failure_modes_detected)
+
+
+def test_reversed_force_direction_gates_to_zero():
+    """Same magnitude but the force is reversed (180 deg) -> identical result magnitudes,
+    so accuracy is blind and only the load check catches it -> gate."""
+    rep = score_trusted_payloads(
+        STEP, {**LABEL, "loads": [{"type": "force", "magnitude_N": 500.0, "direction": [0, 0, 1]}]},
+        _cand(loads=[{"type": "force", "magnitude_N": 500.0, "direction": [0, 0, -1]}]))
+    assert rep.overall_score == 0
+    assert any(f["code"] == FailureMode.WRONG_LOAD for f in rep.failure_modes_detected)
+    assert rep.gates_triggered
+
+
+def test_misaligned_force_direction_gates_to_zero():
+    """Past the tight alignment bound (>= 15 deg) the load points the wrong way -> gate."""
+    rep = score_trusted_payloads(
+        STEP, {**LABEL, "loads": [{"type": "force", "magnitude_N": 500.0, "direction": [0, 0, 1]}]},
+        _cand(loads=[{"type": "force", "magnitude_N": 500.0, "direction": [1, 0, 0]}]))   # 90 deg
+    assert rep.overall_score == 0
+    assert rep.gates_triggered
+    assert any(f["code"] == FailureMode.WRONG_LOAD for f in rep.failure_modes_detected)
+
+
+def test_small_direction_offset_penalized_not_gated():
+    """A small (6-15 deg) direction offset is a wrong load -> penalty, but not yet a gate."""
+    rep = score_trusted_payloads(
+        STEP, {**LABEL, "loads": [{"type": "force", "magnitude_N": 500.0, "direction": [0, 0, 1]}]},
+        _cand(loads=[{"type": "force", "magnitude_N": 500.0,
+                      "direction": [0.1736, 0, 0.9848]}]))   # ~10 deg off
+    assert not rep.gates_triggered
+    assert 0 < rep.subscores["problem_setup"] < 100
+    assert any(f["code"] == FailureMode.WRONG_LOAD for f in rep.failure_modes_detected)
+
+
+def test_matching_load_magnitude_and_direction_scores_high():
+    """Right magnitude and direction -> no load finding, still excellent."""
+    rep = score_trusted_payloads(
+        STEP, {**LABEL, "loads": [{"type": "force", "magnitude_N": 500.0, "direction": [0, 0, 1]}]},
+        _cand(loads=[{"type": "force", "magnitude_N": 500.0, "direction": [0, 0, 1]}]))
+    assert rep.overall_score >= 90
+    assert not any(f["code"] == FailureMode.WRONG_LOAD for f in rep.failure_modes_detected)
+
+
+def _fl(mag, centroid, direction=(0.0, 0.0, 1.0)):
+    """A force load at a resolved face (centroid + direction), as the adapter emits."""
+    return {"type": "force", "magnitude_N": mag, "centroid": list(centroid),
+            "direction": list(direction)}
+
+
+def test_per_face_matched_loads_score_high():
+    """Same loads at the same faces -> matched per face -> no load finding."""
+    loads = [_fl(1000, (10, 0, 0)), _fl(500, (-10, 0, 0))]
+    rep = score_trusted_payloads(STEP, {**LABEL, "loads": loads},
+                                _cand(loads=[_fl(1000, (10, 0, 0)), _fl(500, (-10, 0, 0))]))
+    assert rep.overall_score >= 90
+    assert not any(f["code"] == FailureMode.WRONG_LOAD for f in rep.failure_modes_detected)
+
+
+def test_compensating_swap_caught_though_totals_match():
+    """Loads swapped between two faces: the net-aggregate total is identical (1500 N), so
+    the old aggregate missed it - per-face matching catches the 1000<->500 swap and gates."""
+    label_loads = [_fl(1000, (10, 0, 0)), _fl(500, (-10, 0, 0))]
+    cand_loads = [_fl(500, (10, 0, 0)), _fl(1000, (-10, 0, 0))]
+    rep = score_trusted_payloads(STEP, {**LABEL, "loads": label_loads}, _cand(loads=cand_loads))
+    assert rep.overall_score == 0
+    assert any(f["code"] == FailureMode.WRONG_LOAD for f in rep.failure_modes_detected)
+    assert rep.gates_triggered
+
+
+def test_load_on_wrong_face_flagged_missing_and_spurious():
+    """A load on a different face than the label's -> unmatched: a missing load at the
+    label's face and a spurious one at the candidate's (neither gates on its own)."""
+    rep = score_trusted_payloads(STEP, {**LABEL, "loads": [_fl(500, (0, 0, 0))]},
+                                _cand(loads=[_fl(500, (300, 0, 0))]))   # > match_tol apart
+    assert any(f["code"] == FailureMode.WRONG_LOAD for f in rep.failure_modes_detected)
+    assert any("applies none there" in fb or "not present in the label" in fb
+               for fb in rep.engineering_feedback)
+
+
+def test_geometry_mismatch_vs_step_gates_to_zero():
+    rep = score_trusted_payloads(STEP, LABEL, _cand(
+        geometry={"volume_mm3": 5.0e6, "characteristic_length_mm": 660.0}))
+    assert rep.overall_score == 0
+    assert any(f["code"] == FailureMode.GEOMETRY_MISMATCH for f in rep.failure_modes_detected)
+
+
+def test_wrong_material_vs_label_flagged():
+    rep = score_trusted_payloads(STEP, LABEL, _cand(material={"E_MPa": 70000.0, "nu": 0.33}))
+    assert any(f["code"] == FailureMode.WRONG_MATERIAL for f in rep.failure_modes_detected)
+
+
+def test_missing_restraint_caps_score():
+    rep = score_trusted_payloads(STEP, LABEL, _cand(boundary_conditions=[]))
+    assert any(f["code"] == FailureMode.MISSING_BOUNDARY_CONDITION for f in rep.failure_modes_detected)
+
+
+def test_physically_impossible_gates_to_zero():
+    rep = score_trusted_payloads(STEP, LABEL, _cand(
+        results={"max_displacement_mm": 800.0, "max_von_mises_MPa": 0.35, "max_shear_MPa": 0.19}))
+    assert rep.overall_score == 0
+    assert any(f["code"] == FailureMode.PHYSICALLY_IMPOSSIBLE for f in rep.failure_modes_detected)
+
+
+def test_candidate_extraction_failure_gates_to_zero():
+    candidate = {
+        "solver": {"converged": False},
+        "results": {},
+        "artifacts": {},
+        "meta": {"candidate_extraction_failure": "no FEM result object found"},
+    }
+    rep = score_trusted_payloads(STEP, LABEL, candidate)
+    assert rep.overall_score == 0
+    assert rep.grade == "invalid"
+    assert any(f["code"] == FailureMode.MISSING_RESULTS for f in rep.failure_modes_detected)
+    assert any("candidate_extraction_failure" in evidence for evidence in rep.evidence)
+
+
+def test_failed_solver_replay_gates_to_zero_even_with_claimed_solver_evidence():
+    candidate = _cand(meta={
+        "solver_replay": {
+            "passed": False,
+            "status": "mismatch",
+            "failures": ["DisplacementLengths peak error 90% exceeds 2%"],
+        },
+    })
+    rep = score_trusted_payloads(STEP, LABEL, candidate)
+
+    assert rep.overall_score == 0
+    assert rep.grade == "invalid"
+    assert any(
+        failure["code"] == FailureMode.UNVERIFIED_SOLVER_OUTPUT
+        for failure in rep.failure_modes_detected
+    )
+    assert rep.pass_fail_flags["not_hallucinated"] is False
+
+
+def test_verified_replay_is_reproducibility_evidence_without_fake_input_deck():
+    candidate = _cand(
+        solver={"converged": True, "replay_verified": True},
+        artifacts={"result_file": "candidate.FCStd"},
+        meta={"solver_replay": {"passed": True, "status": "verified"}},
+    )
+    rep = score_trusted_payloads(STEP, LABEL, candidate)
+
+    assert rep.reproducibility_status == "reproducible"
+    assert not any(
+        failure["code"] == FailureMode.NON_REPRODUCIBLE
+        for failure in rep.failure_modes_detected
+    )
+
+
+def test_accepted_replay_is_reproducibility_evidence_without_fake_input_deck():
+    candidate = _cand(
+        solver={"converged": True, "replay_verified": False, "replay_accepted": True},
+        artifacts={"result_file": "candidate.FCStd"},
+        meta={"solver_replay": {"passed": True, "status": "accepted_mismatch"}},
+    )
+    rep = score_trusted_payloads(STEP, LABEL, candidate)
+
+    assert rep.reproducibility_status == "reproducible"
+    assert not any(
+        failure["code"] == FailureMode.NON_REPRODUCIBLE
+        for failure in rep.failure_modes_detected
+    )
+
+
+def test_candidate_fcstd_extraction_requires_trusted_solver_replay():
+    with TemporaryDirectory() as extract_dir:
+        with patch("freecad_validator.fem.step_interface._extract", side_effect=[STEP, LABEL, _cand()]) as extract:
+            score_step_fcstd(
+                "source.step",
+                "reference.FCStd",
+                "candidate.FCStd",
+                freecad_cmd="/fake/freecadcmd",
+                extract_dir=extract_dir,
+            )
+
+    assert extract.call_args_list[0].kwargs.get("extra_args") is None
+    assert extract.call_args_list[1].kwargs.get("extra_args") is None
+    assert extract.call_args_list[2].kwargs["extra_args"] == ["verify-solve"]
+
+
+def test_required_boolean_raw_step_topology_gates_before_full_scoring():
+    source_geometry = _topology_geometry([1.0e6])
+    reference_geometry = _topology_geometry(
+        [0.4e6, 0.6e6],
+        num_compsolids=1,
+        shape_types=["CompSolid"],
+    )
+    with TemporaryDirectory() as extract_dir:
+        with patch(
+            "freecad_validator.fem.step_interface._extract",
+            side_effect=[
+                source_geometry,
+                {"geometry": reference_geometry},
+                {"geometry": source_geometry},
+            ],
+        ) as extract:
+            rep = score_step_fcstd(
+                "source.step",
+                "reference.FCStd",
+                "candidate.FCStd",
+                freecad_cmd="/fake/freecadcmd",
+                extract_dir=extract_dir,
+                require_boolean=True,
+            )
+
+    assert rep.overall_score == 0
+    assert rep.gates_triggered == [{"reason": FailureMode.BOOLEAN_NOT_PERFORMED}]
+    assert len(extract.call_args_list) == 3
+    assert extract.call_args_list[1].kwargs["extra_args"] == ["geometry-only"]
+    assert extract.call_args_list[2].kwargs["extra_args"] == ["geometry-only"]
+
+
+def test_required_boolean_minimum_topology_allows_per_region_differences():
+    source_geometry = _topology_geometry([1.0e6])
+    reference_geometry = _topology_geometry(
+        [0.4e6, 0.6e6],
+        num_compsolids=1,
+        shape_types=["CompSolid"],
+    )
+    candidate_gate_geometry = _topology_geometry(
+        [0.25e6, 0.75e6],
+        num_compsolids=1,
+        shape_types=["CompSolid"],
+    )
+    candidate_gate_geometry["regions"][0].update({
+        "surface_area_mm2": 125.0,
+        "num_faces": 50,
+        "num_edges": 75,
+    })
+    candidate_gate_geometry["regions"][1].update({
+        "surface_area_mm2": 875.0,
+        "num_faces": 60,
+        "num_edges": 90,
+    })
+    candidate_gate_geometry["num_faces"] = 110
+    candidate_gate_geometry["num_edges"] = 165
+    label = {**LABEL, "geometry": reference_geometry}
+    candidate = _cand(geometry=reference_geometry)
+    with TemporaryDirectory() as extract_dir:
+        with patch(
+            "freecad_validator.fem.step_interface._extract",
+            side_effect=[
+                source_geometry,
+                {"geometry": reference_geometry},
+                {"geometry": candidate_gate_geometry},
+                label,
+                candidate,
+            ],
+        ) as extract:
+            rep = score_step_fcstd(
+                "source.step",
+                "reference.FCStd",
+                "candidate.FCStd",
+                freecad_cmd="/fake/freecadcmd",
+                extract_dir=extract_dir,
+                require_boolean=True,
+            )
+
+    assert source_geometry["volume_mm3"] == reference_geometry["volume_mm3"]
+    assert source_geometry["surface_area_mm2"] == reference_geometry["surface_area_mm2"]
+    assert rep.overall_score > 0
+    assert rep.gates_triggered == []
+    assert len(extract.call_args_list) == 5
+    assert extract.call_args_list[-1].kwargs["extra_args"] == ["verify-solve"]
+
+
+def test_required_boolean_wrong_topology_gates_as_geometry_mismatch():
+    source_geometry = _topology_geometry([1.0e6])
+    reference_geometry = _topology_geometry(
+        [0.4e6, 0.6e6],
+        num_compsolids=1,
+        shape_types=["CompSolid"],
+    )
+    wrong_geometry = _topology_geometry([0.2e6, 0.3e6, 0.5e6])
+    with TemporaryDirectory() as extract_dir:
+        with patch(
+            "freecad_validator.fem.step_interface._extract",
+            side_effect=[
+                source_geometry,
+                {"geometry": reference_geometry},
+                {"geometry": wrong_geometry},
+            ],
+        ) as extract:
+            rep = score_step_fcstd(
+                "source.step",
+                "reference.FCStd",
+                "candidate.FCStd",
+                freecad_cmd="/fake/freecadcmd",
+                extract_dir=extract_dir,
+                require_boolean=True,
+            )
+
+    assert rep.overall_score == 0
+    assert rep.gates_triggered == [{"reason": FailureMode.GEOMETRY_MISMATCH}]
+    assert len(extract.call_args_list) == 3
+
+
+def test_required_boolean_wrong_container_gates_as_geometry_mismatch():
+    source_geometry = _topology_geometry([0.4e6, 0.6e6])
+    reference_geometry = _topology_geometry(
+        [0.4e6, 0.6e6],
+        num_compsolids=1,
+        shape_types=["CompSolid"],
+    )
+    wrong_container_geometry = _topology_geometry([0.3e6, 0.7e6])
+    with TemporaryDirectory() as extract_dir:
+        with patch(
+            "freecad_validator.fem.step_interface._extract",
+            side_effect=[
+                source_geometry,
+                {"geometry": reference_geometry},
+                {"geometry": wrong_container_geometry},
+            ],
+        ) as extract:
+            rep = score_step_fcstd(
+                "source.step",
+                "reference.FCStd",
+                "candidate.FCStd",
+                freecad_cmd="/fake/freecadcmd",
+                extract_dir=extract_dir,
+                require_boolean=True,
+            )
+
+    assert rep.overall_score == 0
+    assert rep.gates_triggered == [{"reason": FailureMode.GEOMETRY_MISMATCH}]
+    assert "num_compsolids" in rep.evidence[1]
+    assert "shape_types" in rep.evidence[2]
+    assert len(extract.call_args_list) == 3
+
+
+def test_required_boolean_rejects_indistinguishable_reference_topology():
+    geometry = _topology_geometry([1.0e6])
+    with TemporaryDirectory() as extract_dir:
+        with patch(
+            "freecad_validator.fem.step_interface._extract",
+            side_effect=[
+                geometry,
+                {"geometry": geometry},
+                {"geometry": geometry},
+            ],
+        ):
+            with pytest.raises(ExtractionError, match="indistinguishable"):
+                score_step_fcstd(
+                    "source.step",
+                    "reference.FCStd",
+                    "candidate.FCStd",
+                    freecad_cmd="/fake/freecadcmd",
+                    extract_dir=extract_dir,
+                    require_boolean=True,
+                )
+
+
+def test_required_preprocessing_matching_label_geometry_gates_before_other_scoring():
+    input_geometry = {"volume_mm3": 1.0e6, "surface_area_mm2": 2.5e5}
+    matching_geometry = {
+        "geometry": {"volume_mm3": 1.0e6, "surface_area_mm2": 2.5e5}
+    }
+    with TemporaryDirectory() as extract_dir:
+        with patch(
+            "freecad_validator.fem.step_interface._extract",
+            side_effect=[input_geometry, matching_geometry],
+        ) as extract:
+            rep = score_step_fcstd(
+                "source.step",
+                "reference.FCStd",
+                "candidate.FCStd",
+                freecad_cmd="/fake/freecadcmd",
+                extract_dir=extract_dir,
+                require_preprocessing=True,
+            )
+
+    assert rep.overall_score == 0
+    assert rep.grade == "invalid"
+    assert rep.gates_triggered == [{"reason": FailureMode.PREPROCESSING_NOT_PERFORMED}]
+    assert len(extract.call_args_list) == 2
+    assert extract.call_args_list[0].kwargs.get("extra_args") is None
+    assert extract.call_args_list[1].kwargs["extra_args"] == ["geometry-only"]
+
+
+def test_required_preprocessing_changed_geometry_continues_normal_scoring():
+    input_geometry = {"volume_mm3": 1.0e6, "surface_area_mm2": 2.5e5}
+    candidate_geometry = {
+        "geometry": {"volume_mm3": 0.75e6, "surface_area_mm2": 2.0e5}
+    }
+    preprocessing_label = {
+        **LABEL,
+        "geometry": {"volume_mm3": 0.75e6, "characteristic_length_mm": 387.0},
+    }
+    candidate = _cand(
+        geometry={"volume_mm3": 0.75e6, "characteristic_length_mm": 387.0}
+    )
+    with TemporaryDirectory() as extract_dir:
+        with patch(
+            "freecad_validator.fem.step_interface._extract",
+            side_effect=[input_geometry, candidate_geometry, preprocessing_label, candidate],
+        ) as extract:
+            rep = score_step_fcstd(
+                "source.step",
+                "reference.FCStd",
+                "candidate.FCStd",
+                freecad_cmd="/fake/freecadcmd",
+                extract_dir=extract_dir,
+                require_preprocessing=True,
+            )
+
+    assert rep.overall_score > 0
+    assert not any(
+        failure["code"] == FailureMode.GEOMETRY_MISMATCH
+        for failure in rep.failure_modes_detected
+    )
+    assert any("reference FCStd geometry target" in item for item in rep.evidence)
+    assert len(extract.call_args_list) == 4
+    assert extract.call_args_list[0].kwargs.get("extra_args") is None
+    assert extract.call_args_list[1].kwargs["extra_args"] == ["geometry-only"]
+    assert extract.call_args_list[-1].kwargs["extra_args"] == ["verify-solve"]
+
+
+def test_corrupt_candidate_is_scored_zero_after_trusted_inputs_extract():
+    with TemporaryDirectory() as extract_dir:
+        with patch("freecad_validator.fem.step_interface._extract", side_effect=[
+                STEP, LABEL, ExtractionError("candidate FCStd is corrupt")]) as extract:
+            rep = score_step_fcstd(
+                "source.step",
+                "reference.FCStd",
+                "candidate.FCStd",
+                freecad_cmd="/fake/freecadcmd",
+                extract_dir=extract_dir,
+            )
+
+    assert rep.overall_score == 0
+    assert rep.grade == "invalid"
+    assert [call.args[2] for call in extract.call_args_list] == [
+        "source.step", "reference.FCStd", "candidate.FCStd"]
+    assert any("candidate FCStd is corrupt" in evidence for evidence in rep.evidence)
+
+
+def test_candidate_no_result_payload_is_scored_zero():
+    with TemporaryDirectory() as extract_dir:
+        with patch("freecad_validator.fem.step_interface._extract", side_effect=[
+                STEP, LABEL, {"no_result": True, "extraction_error": "no FEM result object found"}]):
+            rep = score_step_fcstd(
+                "source.step",
+                "reference.FCStd",
+                "candidate.FCStd",
+                freecad_cmd="/fake/freecadcmd",
+                extract_dir=extract_dir,
+            )
+
+    assert rep.overall_score == 0
+    assert rep.grade == "invalid"
+    assert any("no FEM result object found" in evidence for evidence in rep.evidence)
+
+
+def test_reference_extraction_failure_remains_infrastructure_error():
+    with TemporaryDirectory() as extract_dir:
+        with patch("freecad_validator.fem.step_interface._extract", side_effect=[
+                STEP, ExtractionError("reference FCStd is corrupt")]):
+            with pytest.raises(ExtractionError, match="reference FCStd is corrupt"):
+                score_step_fcstd(
+                    "source.step",
+                    "reference.FCStd",
+                    "candidate.FCStd",
+                    freecad_cmd="/fake/freecadcmd",
+                    extract_dir=extract_dir,
+                )
+
+
+def test_reference_no_result_payload_remains_infrastructure_error():
+    with TemporaryDirectory() as extract_dir:
+        with patch("freecad_validator.fem.step_interface._extract", side_effect=[
+                STEP, {"no_result": True, "extraction_error": "no FEM result object found"}]):
+            with pytest.raises(ExtractionError, match="reference FCStd contains no loaded FEM result"):
+                score_step_fcstd(
+                    "source.step",
+                    "reference.FCStd",
+                    "candidate.FCStd",
+                    freecad_cmd="/fake/freecadcmd",
+                    extract_dir=extract_dir,
+                )
+
+
+def test_extract_does_not_reuse_stale_json():
+    with TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        freecad_cmd = temp_path / "freecadcmd"
+        freecad_cmd.write_text("", encoding="utf-8")
+        out_path = temp_path / "candidate.json"
+        out_path.write_text('{"results": {"stale": true}}', encoding="utf-8")
+        process = Mock(pid=1234)
+        process.wait.return_value = 1
+
+        with patch("freecad_validator.fem.step_interface.subprocess.Popen", return_value=process):
+            with pytest.raises(ExtractionError, match="adapter failed with exit 1"):
+                _extract(str(freecad_cmd), "adapter.py", "candidate.FCStd", str(out_path))
+
+        assert not out_path.exists()
+
+
+def test_adapter_timeout_terminates_process_tree(tmp_path):
+    freecad_cmd = tmp_path / "freecadcmd"
+    freecad_cmd.write_text("", encoding="utf-8")
+    process = Mock(pid=1234)
+    process.wait.side_effect = [subprocess.TimeoutExpired("adapter", 0.01), 0]
+    process.poll.return_value = None
+
+    with (
+        patch("freecad_validator.fem.step_interface.subprocess.Popen", return_value=process),
+        patch("freecad_validator.fem.step_interface._terminate_process_tree") as terminate,
+        pytest.raises(ExtractionError, match="timed out after 0.01 seconds"),
+    ):
+        _run_adapter(
+            str(freecad_cmd),
+            "adapter.py",
+            str(tmp_path / "out.json"),
+            [],
+            0.01,
+        )
+    terminate.assert_called_once_with(process)
+
+
+def test_runtime_failure_is_not_scored_as_candidate_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "freecad_validator.fem.step_interface._runtime_preflight",
+        Mock(side_effect=RuntimeEnvironmentError("CalculiX unavailable")),
+    )
+    with pytest.raises(RuntimeEnvironmentError, match="CalculiX unavailable"):
+        score_step_fcstd(
+            "source.step",
+            "reference.FCStd",
+            "candidate.FCStd",
+            freecad_cmd="/fake/freecadcmd",
+            extract_dir=str(tmp_path),
+        )
+
+
+def test_report_includes_runtime_provenance():
+    with TemporaryDirectory() as extract_dir:
+        with patch(
+            "freecad_validator.fem.step_interface._extract",
+            side_effect=[STEP, LABEL, _cand()],
+        ):
+            report = score_step_fcstd(
+                "source.step",
+                "reference.FCStd",
+                "candidate.FCStd",
+                freecad_cmd="/fake/freecadcmd",
+                extract_dir=extract_dir,
+            )
+    assert report.runtime_provenance["freecad"] == "1.1.0"
+    assert report.runtime_provenance["calculix"] == "2.23"
+
+
+def test_adapter_import_does_not_initialize_package(tmp_path):
+    """The installed adapter can run under another interpreter without package init."""
+    (tmp_path / "FreeCAD.py").write_text(
+        "class Units:\n    pass\n",
+        encoding="utf-8",
+    )
+    femtools = tmp_path / "femtools"
+    femtools.mkdir()
+    (femtools / "ccxtools.py").write_text(
+        "class FemToolsCcx:\n    pass\n",
+        encoding="utf-8",
+    )
+    env = {"PYTHONPATH": str(tmp_path), "PATH": ""}
+    completed = subprocess.run(
+        [sys.executable, FCSTD_ADAPTER, "import-check"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == (
+        "[fcstd_adapter] pure replay module loaded"
+    )
+
+
+# --- mesh-budget category (candidate #elements vs label baseline) ---------- #
+def test_mesh_budget_active_with_label():
+    rep = score_trusted_payloads(STEP, LABEL, _cand())   # 12000 == baseline 12000
+    assert rep.subscores_details["mesh_budget"]["weight"] == 0.25
+    assert rep.subscores["mesh_budget"] == 100.0  # at/below baseline -> full
+
+
+def test_mesh_budget_fewer_elements_not_penalised():
+    rep = score_trusted_payloads(STEP, LABEL, _cand(mesh={"num_elements": 6000}))
+    assert rep.subscores["mesh_budget"] == 100.0
+
+
+def test_mesh_budget_partial_when_over():
+    # 12000 * 1.15 = 13800 -> halfway to the 130% ceiling -> ~50
+    rep = score_trusted_payloads(STEP, LABEL, _cand(mesh={"num_elements": 13800}))
+    assert 45 <= rep.subscores["mesh_budget"] <= 55
+    assert rep.pass_fail_flags["mesh_within_budget"] is True
+
+
+def test_mesh_budget_zero_at_130_percent():
+    rep = score_trusted_payloads(STEP, LABEL, _cand(mesh={"num_elements": 15600}))  # 130%
+    assert rep.subscores["mesh_budget"] == 0.0
+    assert any(f["code"] == "MESH_BUDGET_EXCEEDED" for f in rep.failure_modes_detected)
+    assert rep.pass_fail_flags["mesh_within_budget"] is False
+
+
+def test_mesh_budget_costs_25_points_when_zero():
+    """An otherwise-perfect candidate that blows the mesh budget loses ~25 pts."""
+    full = score_trusted_payloads(STEP, LABEL, _cand()).overall_score
+    over = score_trusted_payloads(STEP, LABEL, _cand(mesh={"num_elements": 16000})).overall_score
+    assert full - over >= 20
+
+
+def test_mesh_budget_underresolved_floor_not_spoofable():
+    """A trivially coarse mesh cannot spoof full mesh-budget credit.
+
+    Regression for the mesh-budget spoof: an agent could solve on a fine mesh, then
+    attach a 1-element mesh to the result so the budget reads 'fewer elements ->
+    full credit'. A mesh below the floor (5% of baseline = 600) now scores 0, so the
+    25% efficiency share cannot be farmed with a degenerate mesh."""
+    rep = score_trusted_payloads(STEP, LABEL, _cand(mesh={"num_elements": 1}))
+    assert rep.subscores["mesh_budget"] == 0.0
+    assert any(f["code"] == "MESH_BUDGET_UNDERRESOLVED" for f in rep.failure_modes_detected)
+    assert rep.pass_fail_flags["mesh_within_budget"] is False
+    # and a legitimately efficient mesh just above the floor still earns full credit
+    ok = score_trusted_payloads(STEP, LABEL, _cand(mesh={"num_elements": 6000}))
+    assert ok.subscores["mesh_budget"] == 100.0
+
+
+if __name__ == "__main__":
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for fn in fns:
+        fn()
+        print("ok:", fn.__name__)
+    print(f"{len(fns)} step-interface tests passed")

--- a/tests/unit/test_freecad_loader_paths.py
+++ b/tests/unit/test_freecad_loader_paths.py
@@ -9,10 +9,13 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import pytest
+
 from freecad_validator._freecad_loader import (
     _candidate_paths,
     _linux_mod_dirs,
     _looks_like_freecad_lib,
+    resolve_freecad_command,
 )
 
 
@@ -82,3 +85,27 @@ def test_mod_dirs_pair_with_a_linux_lib_dir():
 def test_pathsep_is_the_documented_list_separator():
     """FREECAD_LIB is split on os.pathsep, matching PATH/PYTHONPATH."""
     assert os.pathsep in (":", ";")
+
+
+def test_explicit_freecad_command_is_resolved(tmp_path):
+    command = tmp_path / "freecadcmd"
+    command.write_text("#!/bin/sh\n", encoding="utf-8")
+    command.chmod(0o755)
+
+    assert resolve_freecad_command(command) == str(command.resolve())
+
+
+def test_freecad_command_environment_override(monkeypatch, tmp_path):
+    command = tmp_path / "FreeCADCmd"
+    command.write_text("#!/bin/sh\n", encoding="utf-8")
+    command.chmod(0o755)
+    monkeypatch.setenv("FREECAD_CMD", str(command))
+
+    assert resolve_freecad_command() == str(command.resolve())
+
+
+def test_missing_explicit_freecad_command_fails_clearly(tmp_path):
+    missing = tmp_path / "missing-freecadcmd"
+
+    with pytest.raises(FileNotFoundError, match="not found or is not executable"):
+        resolve_freecad_command(missing)

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -25,6 +25,9 @@ def test_subpackages_import():
     import freecad_validator.consistency.checks  # noqa: F401
     import freecad_validator.consistency.compare  # noqa: F401
     import freecad_validator.consistency.report  # noqa: F401
+    import freecad_validator.fem  # noqa: F401
+    import freecad_validator.fem.metrics  # noqa: F401
+    import freecad_validator.fem.replay_compare  # noqa: F401
     import freecad_validator.scorers.base  # noqa: F401
     import freecad_validator.spec.parser  # noqa: F401
 

--- a/uv.lock
+++ b/uv.lock
@@ -485,7 +485,7 @@ wheels = [
 
 [[package]]
 name = "gnucleus-freecad-validator"
-version = "0.1.3"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- add a public deterministic FEM validation API for solved FreeCAD/CalculiX analyses
- add FreeCAD extraction, trusted candidate replay, reference comparison, and engineering validity gates
- expose `freecad-validator fem-score` with explicit Boolean and preprocessing requirements
- add portable FreeCAD command discovery, documentation, and external-runtime security guidance
- update the package to 0.2.0 and include the complete canonical Apache 2.0 license text

## Review hardening

- load the pure-Python replay module directly so an installed wheel can run through FreeCAD's different embedded Python version
- retain generic FCStd archive traversal protection without publishing internal exploit details
- add configurable adapter timeouts, process-group termination, and file-backed bounded diagnostics
- preflight FreeCAD, OCCT, embedded Python, and CalculiX before scoring; expose their versions in report provenance
- distinguish validator runtime failures from invalid candidate results
- make the trusted-only boundary of the extracted-payload API explicit
- store logical basenames instead of absolute source paths in extraction output

## Validation

- `ruff check src tests`
- FreeCAD-free suite: 112 passed
- generated public cantilever end-to-end test: FreeCAD 1.1.0 and CalculiX 2.23 solve/replay passed with no validity gates
- installed-wheel boundary test: wheel installed under Python 3.13, adapter executed successfully under Python 3.11
- CI installs a wheel rather than an editable checkout and tests Python 3.12/3.13 wheel adapters under a Python 3.11 embedded-interpreter equivalent
- source distribution and wheel contain no CAD/reference task assets

## Packaging

FreeCAD and CalculiX remain separately installed runtime tools. Neither executable nor task-specific source/reference data is bundled with this package.
