### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gnucleus-freecad-validator"
-version = "0.2.0"
+version = "0.3.0"
 description = "Deterministic validation for FreeCAD geometry, design specifications, and solved FreeCAD/CalculiX FEM analyses."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Bumps the package version to 0.3.0 to release the PartDesign baked-geometry integrity gate (#20), the only change on `main` since `v0.2.0`.

Minor rather than patch: the new gate scores previously-passing documents 0.0 when their solid is not produced by an editable feature tree, so downstream benchmark results move.

## Release notes for the tag

- Rejects baked geometry hidden in `PartDesign::Body` — documents whose solid is not produced by an editable feature tree now score 0.0. **Previously-passing models can now score 0.0**; this is the reason for the minor bump.
- Rejection reasons now name the failing side (`reference model` / `candidate model`) and no longer leak absolute temporary paths.
- A Body whose Tip feature merely failed to recompute is no longer misreported as baked geometry.
- Known limitation: baked geometry assigned to an allowlisted `PartDesign::*` TypeId, or attributed to a decoy feature, is still accepted — deliberately out of scope for this release.

## Testing

CI skips `needs_freecad` tests, so these were run locally against FreeCAD 1.1.0 on the bumped tree:

- `PYTHONPATH="src:/Applications/FreeCAD.app/Contents/Resources/lib" pytest -q` — 174 passed, 4 skipped
- `pytest -q -m needs_freecad` — 43 passed, 3 skipped, 132 deselected
- `ruff check .` / `ruff format --check .` — clean
- `python -m build` — builds `gnucleus_freecad_validator-0.3.0` sdist + wheel, so the tag job will not fail on packaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
