### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gnucleus-freecad-validator"
-version = "0.3.0"
+version = "0.4.0"
 description = "Deterministic validation for FreeCAD geometry, design specifications, and solved FreeCAD/CalculiX FEM analyses."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -439,7 +439,7 @@ wheels = [
 
 [[package]]
 name = "gnucleus-freecad-validator"
-version = "0.2.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## Summary

- bump the package version from 0.3.0 to 0.4.0
- synchronize the uv lockfile local-package version, which was still stale at 0.2.0
- prepare the release for the configurable spec failure budget from #21 and CAD-grounded parameter validation from #24

## Why a minor bump

This release adds a public scoring option and intentionally changes validation behavior. Parameters must now be grounded in candidate CAD evidence, candidate-side param_check.py discovery has been removed, and previously accepted parameters can become not_found. Stored spec-consistency scores should be re-baselined across this version boundary.

## Release highlights

- optional spec failure-budget scoring through Validator and the CLI; disabled by default
- semantic, candidate-CAD-grounded parameter selection instead of matching measurements by proximity to expected values
- hardened structured-spec parsing, units, count/vector/thickness routing, and diagnostics
- trusted param_check.py loading only beside the evaluator-controlled spec JSON
- stronger category validation and a new staircase category

## Verification

- uv run ruff check .
- uv run ruff format --check .
- FreeCAD-free suite: 191 passed, 1 optional-render skip, 46 deselected
- full suite with FreeCAD 1.1.0: 234 passed, 4 expected skips
- uv lock --check
- built gnucleus_freecad_validator-0.4.0-py3-none-any.whl and gnucleus_freecad_validator-0.4.0.tar.gz
- wheel metadata reports version 0.4.0